### PR TITLE
Add next-piece preview toggle + iOS double-tap zoom guard

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,29 @@
+# StackLogic Backlog Notes
+
+Owner (future): Prime (agent)
+Status: Parked for roadmap
+
+## From Codex review (main..staging)
+
+### Should
+1. **Perf / maintainability** (`public/game.js`)
+   - Current: `draw()` reads `localStorage` every frame to determine `previewEnabled`.
+   - Proposed: cache `previewEnabled` in memory; initialize once on load; update via checkbox change handler.
+
+2. **Touch handler scope** (`public/game.js`)
+   - Current: double-tap guard selector is broad (`.btn`, `.pbtn`, etc.).
+   - Proposed: limit to game-control elements only to avoid side effects on future buttons.
+
+### Nice
+1. Add a subtle frame/background behind "Next" preview for readability.
+2. Add lightweight test checklist for:
+   - preview toggle persistence
+   - spawn/next consistency across restart/home flow
+   - iOS double-tap guard behavior
+
+## Gate decision reference
+- PASS (no blockers/security issues)
+- No secrets added in diff
+- No eval usage added
+- No unsafe DOM (`innerHTML`) in changed files
+- No dependency/version changes in diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project are recorded here.
+
+## Unreleased
+- Added title-screen checkbox to toggle "Preview next block" (localStorage key: stacklogic_preview_next_v1).
+- Implemented next-piece preview rendering on canvas and prefetched next piece logic.
+- Fixed preview position so it renders inside the canvas.
+- Added iOS double-tap guard for on-screen controls to reduce accidental zooming.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Current release line: **v0.x beta**.
 ## Notes
 
 This repo is intentionally lightweight and easy to run.
+
+## Backlog / Roadmap Notes
+
+- See `BACKLOG.md` for parked roadmap items, review follow-ups, and handoff notes for future backlog processing.

--- a/public/index.html
+++ b/public/index.html
@@ -59,6 +59,10 @@
 
             <button id="startBtn" class="btn primary" type="button">Start</button>
 
+            <div class="setting">
+              <label><input type="checkbox" id="previewNext" /> Preview next block</label>
+            </div>
+
             <h3 class="subhead">High scores</h3>
             <ol id="highScores" class="scores"></ol>
 


### PR DESCRIPTION
What changed
Added “Preview next block” checkbox on title screen (default: ON).
Saved setting to localStorage (stacklogic_preview_next_v1).
Implemented next-piece preview pipeline (nextType prefetch + render).
Fixed preview placement so it renders inside the play canvas (top-right).
Added iOS rapid double-tap prevention on game controls to reduce accidental page zoom.
Added docs updates:
CHANGELOG.md entry
BACKLOG.md (parked follow-ups)
README.md link to BACKLOG.md
Why
Requested UX feature: optional next-block preview.
Better iOS playability when tapping controls quickly.
Keeps follow-up work tracked for future backlog handling.

Validation
Ran local server on :3000.
Confirmed preview toggle appears and persists.
Confirmed preview shows/hides correctly in gameplay.
Confirmed preview is visible after placement fix.
Confirmed iOS fast-tap zoom mitigation on controls.

Follow-ups (parked)
Cache preview flag in memory (avoid localStorage read in render loop).
Narrow touch guard selector scope further.
Optional visual frame/background behind “Next” preview.
Add lightweight regression checklist.
Next actions (pick up to 3)
If you want, I can give you an even shorter version (3-bullet PR body).
I can also tailor this to match your repo’s usual PR template style.
Once posted, I can draft the merge note for main.