### PR TITLE
feat: refine next-piece preview and iOS touch controls

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -1,5 +1,6 @@
 import { createThemeRainBootstrap } from './theme-rain-bootstrap.js?v=0.2.0-beta.1';
 import { computePreviewFrameLayout, drawPreviewFrame } from './preview-frame.js?v=0.2.0-beta.1';
+import { bindIosDoubleTapGuard } from './ios-double-tap.js';
 
 const COLS = 10;
 const ROWS = 20;
@@ -674,25 +675,7 @@ if (previewCheckbox) {
 }
 
 // Prevent iOS double-tap zoom on fast consecutive taps for controls
-(function() {
-  let lastTouch = 0;
-  const THRESH = 300; // ms
-  function onTouchStart(e) {
-    try {
-      const now = Date.now();
-      if (now - lastTouch < THRESH) {
-        // Too-fast second tap: prevent default to stop double-tap zoom
-        e.preventDefault();
-      }
-      lastTouch = now;
-    } catch (err) {
-      // ignore
-    }
-  }
-  const selector = '#mobileControls, .btn, .pbtn, #startBtn, #goHomeBtn, #portraitRestartBtn, #btnLeft, #btnRight, #btnRotL, #btnRotR, #btnDrop';
-  const els = document.querySelectorAll(selector);
-  els.forEach((el) => el.addEventListener('touchstart', onTouchStart, { passive: false }));
-})();
+bindIosDoubleTapGuard(document.querySelectorAll('#mobileControls button:not(:disabled)'));
 
 function bindHoldButton(btn, onPressOnce, { repeatMs = 0 } = {}) {
   let interval = null;

--- a/public/game.js
+++ b/public/game.js
@@ -1,4 +1,5 @@
 import { createThemeRainBootstrap } from './theme-rain-bootstrap.js?v=0.2.0-beta.1';
+import { computePreviewFrameLayout, drawPreviewFrame } from './preview-frame.js?v=0.2.0-beta.1';
 
 const COLS = 10;
 const ROWS = 20;
@@ -423,29 +424,28 @@ function draw() {
   })();
 
   if (previewEnabled && nextType) {
-    // Render preview in the top-right of the canvas (inside bounds)
     const shape = SHAPES[nextType];
     const small = Math.floor(CELL * 0.7);
-    const padding = 8;
-    // compute pixel base so preview sits inside canvas on the right
-    const previewWidth = Math.max(...shape.map((r) => r.length)) * small;
-    const previewHeight = shape.length * small;
-    const basePx = canvas.width - previewWidth - padding;
-    const basePy = padding;
+    const layout = computePreviewFrameLayout({
+      canvasWidth: canvas.width,
+      canvasHeight: canvas.height,
+      shape,
+      cellSize: small,
+    });
+    const styles = getComputedStyle(document.documentElement);
+    const borderColor = styles.getPropertyValue('--border').trim() || '#283244';
+    const labelColor = styles.getPropertyValue('--fg').trim() || '#e6edf3';
+
+    drawPreviewFrame(ctx, layout, { borderColor, labelColor });
 
     for (let y = 0; y < shape.length; y++) {
       for (let x = 0; x < shape[y].length; x++) {
         if (!shape[y][x]) continue;
-        drawBrickAt(ctx, basePx + x * small, basePy + y * small, COLORS[nextType],
+        drawBrickAt(ctx, layout.pieceX + x * small, layout.pieceY + y * small, COLORS[nextType],
           (typeof window !== 'undefined' && window.ThemeModule && window.ThemeModule.getCurrentTheme)
             ? window.ThemeModule.getCurrentTheme() : 'Default', small);
       }
     }
-
-    // Draw label above preview
-    ctx.fillStyle = '#fff';
-    ctx.font = '12px sans-serif';
-    ctx.fillText('Next', basePx, basePy - 6);
   }
 }
 

--- a/public/ios-double-tap.js
+++ b/public/ios-double-tap.js
@@ -1,0 +1,37 @@
+export const IOS_DOUBLE_TAP_THRESHOLD_MS = 300;
+
+/**
+ * Install a touchstart listener on each enabled button that prevents the default
+ * action when two taps occur within IOS_DOUBLE_TAP_THRESHOLD_MS on the same control.
+ * Returns a disposer function that removes all installed listeners.
+ */
+export function bindIosDoubleTapGuard(buttons, { now = Date.now } = {}) {
+  const lastTapTime = new Map();
+  const disposers = [];
+
+  for (const btn of buttons) {
+    if (btn.disabled) continue;
+
+    const handler = (e) => {
+      if (!e.cancelable) return;
+      const nowMs = now();
+      const prev = lastTapTime.get(btn);
+      if (prev !== undefined && (nowMs - prev) >= 0 && (nowMs - prev) < IOS_DOUBLE_TAP_THRESHOLD_MS) {
+        e.preventDefault();
+      }
+      lastTapTime.set(btn, nowMs);
+    };
+
+    btn.addEventListener('touchstart', handler, { passive: false });
+    disposers.push(() => {
+      btn.removeEventListener('touchstart', handler, { passive: false });
+      lastTapTime.delete(btn);
+    });
+  }
+
+  return () => {
+    for (const dispose of disposers) {
+      dispose();
+    }
+  };
+}

--- a/public/preview-frame.js
+++ b/public/preview-frame.js
@@ -1,0 +1,73 @@
+export function computePreviewFrameLayout({
+  canvasWidth,
+  canvasHeight,
+  shape,
+  cellSize,
+  outerPadding = 8,
+  framePadding = 6,
+  labelHeight = 16,
+}) {
+  const dimensions = [canvasWidth, canvasHeight, cellSize, outerPadding, framePadding, labelHeight];
+  if (!dimensions.every((value) => Number.isFinite(value) && value > 0)) {
+    throw new Error('preview frame dimensions must be finite positive numbers');
+  }
+  if (
+    !Array.isArray(shape)
+    || shape.length === 0
+    || !shape.every((row) => Array.isArray(row) && row.length > 0)
+  ) {
+    throw new Error('shape must contain non-empty rows');
+  }
+
+  const columns = Math.max(...shape.map((row) => row.length));
+  const rows = shape.length;
+  const pieceWidth = columns * cellSize;
+  const pieceHeight = rows * cellSize;
+  const frameWidth = pieceWidth + 2 * framePadding;
+  const frameHeight = labelHeight + pieceHeight + 3 * framePadding;
+  const frameX = canvasWidth - outerPadding - frameWidth;
+  const frameY = outerPadding;
+  const pieceX = frameX + framePadding;
+  const pieceY = frameY + labelHeight + framePadding;
+  const labelX = frameX + framePadding;
+  const labelY = frameY + 2 * framePadding;
+
+  if (
+    frameX < 0
+    || frameY < 0
+    || frameX + frameWidth > canvasWidth
+    || frameY + frameHeight > canvasHeight
+  ) {
+    throw new Error('preview frame does not fit inside the canvas');
+  }
+
+  return {
+    frameX,
+    frameY,
+    frameWidth,
+    frameHeight,
+    pieceX,
+    pieceY,
+    pieceWidth,
+    pieceHeight,
+    labelX,
+    labelY,
+  };
+}
+
+export function drawPreviewFrame(context, layout, { borderColor, labelColor }) {
+  context.save();
+  context.strokeStyle = borderColor;
+  context.fillStyle = labelColor;
+  context.lineWidth = 1;
+  context.font = '12px sans-serif';
+  context.textBaseline = 'alphabetic';
+  context.strokeRect(
+    layout.frameX + 0.5,
+    layout.frameY + 0.5,
+    layout.frameWidth - 1,
+    layout.frameHeight - 1,
+  );
+  context.fillText('Next', layout.labelX, layout.labelY);
+  context.restore();
+}

--- a/tests/ios-double-tap.test.mjs
+++ b/tests/ios-double-tap.test.mjs
@@ -1,0 +1,104 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  IOS_DOUBLE_TAP_THRESHOLD_MS,
+  bindIosDoubleTapGuard,
+} from '../public/ios-double-tap.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const gameSource = readFileSync(join(__dirname, '..', 'public', 'game.js'), 'utf8');
+
+class FakeButton {
+  constructor({ disabled = false } = {}) {
+    this.disabled = disabled;
+    this.listeners = new Map();
+    this.removed = [];
+  }
+
+  addEventListener(type, listener, options) {
+    this.listeners.set(type, { listener, options });
+  }
+
+  removeEventListener(type, listener, options) {
+    this.removed.push({ type, listener, options });
+    if (this.listeners.get(type)?.listener === listener) this.listeners.delete(type);
+  }
+
+  touch() {
+    const record = this.listeners.get('touchstart');
+    assert.ok(record, 'touchstart listener must be installed');
+    const event = {
+      cancelable: true,
+      prevented: false,
+      preventDefault() { this.prevented = true; },
+    };
+    record.listener(event);
+    return event;
+  }
+}
+
+describe('iOS double-tap zoom guard', () => {
+  it('suppresses only a fast second tap on the same enabled control', () => {
+    let now = 1_000;
+    const left = new FakeButton();
+    const right = new FakeButton();
+    const disabled = new FakeButton({ disabled: true });
+
+    const dispose = bindIosDoubleTapGuard([left, right, disabled], { now: () => now });
+
+    assert.equal(IOS_DOUBLE_TAP_THRESHOLD_MS, 300);
+    assert.deepEqual(left.listeners.get('touchstart').options, { passive: false });
+    assert.deepEqual(right.listeners.get('touchstart').options, { passive: false });
+    assert.equal(disabled.listeners.has('touchstart'), false, 'disabled controls stay unguarded');
+
+    assert.equal(left.touch().prevented, false, 'first left tap is allowed');
+    now = 1_100;
+    assert.equal(right.touch().prevented, false, 'fast cross-control tap is allowed');
+    now = 1_200;
+    assert.equal(left.touch().prevented, true, 'fast second left tap is guarded');
+    now = 1_400;
+    assert.equal(right.touch().prevented, false, 'tap at the exact threshold is allowed');
+
+    dispose();
+    assert.equal(left.listeners.has('touchstart'), false);
+    assert.equal(right.listeners.has('touchstart'), false);
+    assert.equal(left.removed.length, 1);
+    assert.equal(right.removed.length, 1);
+  });
+
+  it('resets safely when the clock moves backward and ignores non-cancelable touches', () => {
+    let now = 2_000;
+    const button = new FakeButton();
+    bindIosDoubleTapGuard([button], { now: () => now });
+
+    assert.equal(button.touch().prevented, false);
+    now = 1_900;
+    assert.equal(button.touch().prevented, false, 'negative elapsed time is not a double tap');
+
+    now = 2_000;
+    const record = button.listeners.get('touchstart');
+    const event = {
+      cancelable: false,
+      prevented: false,
+      preventDefault() { this.prevented = true; },
+    };
+    record.listener(event);
+    assert.equal(event.prevented, false, 'non-cancelable events are not prevented');
+  });
+
+  it('integrates only with enabled mobile gameplay buttons', () => {
+    assert.match(gameSource, /import\s*\{\s*bindIosDoubleTapGuard\s*\}\s*from\s*['"]\.\/ios-double-tap\.js/);
+    assert.match(
+      gameSource,
+      /bindIosDoubleTapGuard\(document\.querySelectorAll\(['"]#mobileControls button:not\(:disabled\)['"]\)\)/,
+    );
+
+    const legacyBlock = gameSource.match(/\/\/ Prevent iOS double-tap[\s\S]*?function bindHoldButton/);
+    assert.ok(legacyBlock, 'touch guard remains adjacent to the mobile control bindings');
+    assert.doesNotMatch(legacyBlock[0], /\.btn|\.pbtn|#startBtn|#goHomeBtn|#portraitRestartBtn/);
+  });
+});

--- a/tests/preview-frame.test.mjs
+++ b/tests/preview-frame.test.mjs
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  computePreviewFrameLayout,
+  drawPreviewFrame,
+} from '../public/preview-frame.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const gameSource = readFileSync(join(__dirname, '..', 'public', 'game.js'), 'utf8');
+
+const T_SHAPE = [
+  [0, 1, 0],
+  [1, 1, 1],
+  [0, 0, 0],
+];
+
+describe('next-piece preview frame', () => {
+  it('computes a bounded frame with an internal label band and enclosed piece', () => {
+    const layout = computePreviewFrameLayout({
+      canvasWidth: 300,
+      canvasHeight: 600,
+      shape: T_SHAPE,
+      cellSize: 21,
+      outerPadding: 8,
+      framePadding: 6,
+      labelHeight: 16,
+    });
+
+    assert.deepStrictEqual(layout, {
+      frameX: 217,
+      frameY: 8,
+      frameWidth: 75,
+      frameHeight: 97,
+      pieceX: 223,
+      pieceY: 30,
+      pieceWidth: 63,
+      pieceHeight: 63,
+      labelX: 223,
+      labelY: 20,
+    });
+    assert.ok(layout.frameX >= 0 && layout.frameY >= 0);
+    assert.ok(layout.frameX + layout.frameWidth <= 300);
+    assert.ok(layout.frameY + layout.frameHeight <= 600);
+    assert.ok(layout.pieceX >= layout.frameX);
+    assert.ok(layout.pieceY > layout.labelY);
+    assert.ok(layout.pieceX + layout.pieceWidth <= layout.frameX + layout.frameWidth);
+    assert.ok(layout.pieceY + layout.pieceHeight <= layout.frameY + layout.frameHeight);
+  });
+
+  it('draws one crisp lightweight frame and one internal Next label using supplied theme colors', () => {
+    const calls = [];
+    const context = {
+      save() { calls.push(['save']); },
+      restore() { calls.push(['restore']); },
+      strokeRect(...args) { calls.push(['strokeRect', ...args]); },
+      fillText(...args) { calls.push(['fillText', ...args]); },
+      set strokeStyle(value) { calls.push(['strokeStyle', value]); },
+      set fillStyle(value) { calls.push(['fillStyle', value]); },
+      set lineWidth(value) { calls.push(['lineWidth', value]); },
+      set font(value) { calls.push(['font', value]); },
+      set textBaseline(value) { calls.push(['textBaseline', value]); },
+    };
+    const layout = computePreviewFrameLayout({
+      canvasWidth: 300,
+      canvasHeight: 600,
+      shape: T_SHAPE,
+      cellSize: 21,
+    });
+
+    drawPreviewFrame(context, layout, {
+      borderColor: '#283244',
+      labelColor: '#e6edf3',
+    });
+
+    assert.deepStrictEqual(calls, [
+      ['save'],
+      ['strokeStyle', '#283244'],
+      ['fillStyle', '#e6edf3'],
+      ['lineWidth', 1],
+      ['font', '12px sans-serif'],
+      ['textBaseline', 'alphabetic'],
+      ['strokeRect', 217.5, 8.5, 74, 96],
+      ['fillText', 'Next', 223, 20],
+      ['restore'],
+    ]);
+  });
+
+  it('rejects empty or out-of-bounds geometry instead of drawing an invalid frame', () => {
+    assert.throws(
+      () => computePreviewFrameLayout({ canvasWidth: 300, canvasHeight: 600, shape: [], cellSize: 21 }),
+      /shape/,
+    );
+    assert.throws(
+      () => computePreviewFrameLayout({ canvasWidth: 50, canvasHeight: 50, shape: T_SHAPE, cellSize: 21 }),
+      /fit/,
+    );
+  });
+
+  it('is integrated into the live next-piece draw path', () => {
+    assert.match(gameSource, /computePreviewFrameLayout/);
+    assert.match(gameSource, /drawPreviewFrame/);
+    assert.match(gameSource, /getComputedStyle\(document\.documentElement\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a bounded, theme-aware next-piece preview frame
- scope iOS double-tap zoom prevention to enabled gameplay controls
- track touch timing per control while preserving navigation and ordinary zoom behavior

## Verification
- 98/98 Node tests passed in the isolated dev candidate
- independent exact-hash review passed
- real-Chrome runtime acceptance passed with zero console errors
- physical iPad Safari acceptance passed on `stacklogic-dev.game.lan`

## Promotion boundary
- dev only until this PR is reviewed and checks pass
- production has not been modified