### PR TITLE
feat: authoritative multiplayer matches

### DIFF
--- a/PASS-01.md
+++ b/PASS-01.md
@@ -1,0 +1,27 @@
+# StackLogic Pass 01 — Lobby Usability
+
+## Goal
+Finish the existing secure-room lobby usability without adding match gameplay.
+
+## Required behavior
+1. Normalize join input to the server's canonical uppercase room code before sending `join_room`: accept lowercase and ignore spaces/hyphens.
+2. Normalize direct `?room=<code>` prefills, and accept a pasted invite URL containing `?room=<code>` by extracting/normalizing only the room code.
+3. Provide accessible **Copy Code** and **Copy Invite Link** controls that are unavailable before `room_state` and enabled after it.
+4. Copy Code must copy the normalized canonical code from the active `room_state`, never a later edit to the join input.
+5. Copy Invite Link must use the active `room_state` code and contain only the current page origin/path and normalized room code; never include player name, request ID, token, room state, or unrelated query parameters.
+6. Copy must use the modern Clipboard API when available and a user-gesture document-copy fallback on the canonical non-secure HTTP lane; success/failure must use the existing in-page status surface with no `alert()` or `prompt()`.
+7. Preserve current create/join/ready behavior, solo behavior, secure request IDs, and all existing assertions.
+
+## Not in this pass
+- Countdown, match start, opponent board, Duel/garbage gameplay, reconnect, rematch, visual redesign, deployment, commit, or push.
+
+## Writable paths
+- `public/index.html`
+- `public/room-client.js`
+
+## Immutable acceptance gate
+- `tests/multiplayer-lobby-ui.test.mjs`
+
+## Gates
+- `node --test tests/multiplayer-lobby-ui.test.mjs` inside the admitted offline container.
+- Prime separately runs full `npm test` after an accepted patch is projected to the authoritative dev worktree.

--- a/PASS-02.md
+++ b/PASS-02.md
@@ -1,0 +1,48 @@
+# StackLogic Pass 02 — Server-Authoritative Match Start
+
+## Outcome
+
+When exactly two room members are present and the second valid Ready transition makes both players Ready, the server atomically creates one match and both clients begin from the same authoritative match identity and unsigned 32-bit seed.
+
+## Writable product paths
+
+- `room-registry.js`
+- `public/room-client.js`
+- `public/game.js`
+
+No other product path is writable in this pass.
+
+## Immutable acceptance gate
+
+- `tests/multiplayer-match-start.test.mjs`
+
+The implementation and review lanes may read this test but must not alter it.
+
+## Required behavior
+
+1. A room has no `match` property before exactly two players are Ready.
+2. The valid second Ready transition increments the existing room sequence exactly once and atomically adds:
+   - `match.id`: a non-empty bounded ASCII token;
+   - `match.seed`: an integer from `0` through `0xffffffff`;
+   - `match.startedSeq`: the resulting authoritative room sequence.
+3. Default match identity and seed authority use Node cryptographic entropy (`randomUUID` plus a cryptographic unsigned 32-bit seed), never `Math.random`, clocks, or client input.
+4. The registry accepts injected match-ID and seed factories for deterministic tests. Invalid factory output fails with a typed error and leaves room sequence, readiness, and match state unchanged.
+5. A started match cannot be regenerated or returned to lobby readiness through `setPlayerReady`; reject with `match_started` without mutation.
+6. Existing personalized `room_state` broadcasts carry the same detached `room.match` snapshot to both connections. Do not add a second competing match-start protocol message.
+7. The room client validates the authoritative match shape, disables the Ready control, and dispatches exactly one `stacklogic:match-start` browser event per match ID. Repeated room snapshots must not restart the match. Invalid match data must not dispatch.
+8. `public/game.js` listens for that browser event and calls the existing `startGame(seed)` seam with the authoritative seed.
+9. Solo Start continues to call `startGame()` with locally generated cryptographic entropy.
+10. Existing room-code, request-ID, sequence, readiness, lobby-copy, solo progression/scoring, and seeded seven-bag behavior remain intact.
+
+## Non-goals
+
+- board, movement, input, score, line, garbage, pause, or game-over synchronization;
+- matchmaking, spectators, persistence, results, rematches, or reconnect recovery;
+- protocol redesign or dependency changes;
+- push, deployment, release, promotion, or production mutation.
+
+## Acceptance command
+
+```sh
+node --test tests/multiplayer-match-start.test.mjs
+```

--- a/PASS-03.md
+++ b/PASS-03.md
@@ -1,0 +1,138 @@
+# StackLogic Pass 03 — Live Opponent State
+
+Status: runner-owned implementation contract
+Baseline source checkpoint: `fa3be624429f38c28f5ce47a639538195f74e1ad`
+Cumulative fixture baseline: `c1bf65fa03483c55341d23056fbc61fc64ae1f1f`
+Mode: local-only two-Qwen implementation/review cycle
+
+## Primary objective
+
+Use StackLogic as the pilot product to qualify the bounded local implementation and read-only review lanes. The deterministic runner and Prime retain authority for scope, tests, candidate identity, browser acceptance, dev/production isolation, and final decisions.
+
+## Product outcome
+
+After the two-player server-authoritative match start from Pass 02, each browser can see the other player's settled board, score, lines, and game-over status update live.
+
+This pass does **not** make a reported board, score, lines, or game-over flag authoritative gameplay truth. The client reports cosmetic opponent-view state. The server is authoritative only for connection-bound player identity, room and match ownership, strict payload validation, per-player update ordering, storage isolation, and opponent-only relay. A reported game-over flag never adjudicates a winner or stops the other player's game.
+
+## Frozen state schema
+
+A client state update has these exact fields:
+
+```json
+{
+  "board": [[null]],
+  "score": 0,
+  "lines": 0,
+  "gameOver": false
+}
+```
+
+The real board must be exactly 20 rows by 10 columns. Every cell is exactly `null` or one of `I`, `O`, `T`, `S`, `Z`, `J`, `L`. `score` and `lines` are non-negative safe integers no greater than 1,000,000,000. `gameOver` is boolean. The four own enumerable state keys must be exactly `board`, `score`, `lines`, and `gameOver`; inherited substitutes and extra own keys are rejected.
+
+Every update also carries the current bounded ASCII `matchId` and an integer `updateSeq` in `1..1,000,000,000`. A player's first update is sequence 1; every later update must be exactly the previous sequence plus one. One player's update sequence is independent of the room sequence and the other player's sequence.
+
+## Server and protocol outcome
+
+1. `room-registry.js` exposes one `updatePlayerState` authority.
+2. It accepts updates only for an existing room, existing connection-bound player, already-started matching match ID, exact next player sequence, and fully valid detached state.
+3. Invalid input fails before mutation. Use `match_not_started` when no match exists, `match_mismatch` for a valid foreign match ID, `invalid_update_sequence` for a malformed sequence value, `stale_player_state` with numeric `currentUpdateSeq` for a valid duplicate/stale/skipped sequence, and `invalid_player_state` for a malformed state shape or value. Before the first accepted update, authoritative `currentUpdateSeq` is `0`. Existing room/player errors retain their current codes. Duplicate, stale, and skipped sequences never replace the last accepted state.
+4. Accepted state is deep-copied into the player as `gameState`. `updatePlayerState` returns the complete detached room snapshot—preserving top-level `code`, `seq`, `players`, and `match`—with the accepted player's `gameState` visible in that returned snapshot. The room's lobby `seq` remains exactly unchanged.
+5. `room-protocol.js` accepts `update_player_state` through the existing request-ID and connection session boundary. Clients never choose a player ID. The protocol passes only the connection-bound session room code and player ID into `updatePlayerState`; the registry re-reads the authoritative current room and match. Authorization must never depend on the session's stale detached room snapshot.
+6. The sender receives:
+
+```json
+{
+  "type": "player_state_accepted",
+  "protocolVersion": 1,
+  "requestId": "...",
+  "matchId": "...",
+  "updateSeq": 1
+}
+```
+
+7. Only the other currently connected, distinct player session in the same authoritative room receives the dedicated projection; state is not added to `room_state`:
+
+```json
+{
+  "type": "opponent_state",
+  "protocolVersion": 1,
+  "matchId": "...",
+  "opponent": {
+    "name": "Alpha",
+    "updateSeq": 1,
+    "board": [[null]],
+    "score": 0,
+    "lines": 0,
+    "gameOver": false
+  }
+}
+```
+
+8. After the request-ID and in-room session gates, the registry remains the sole match, sequence, and state-shape validator. The protocol must not remap registry `invalid_update_sequence`, `stale_player_state`, `match_mismatch`, or `invalid_player_state` outcomes to generic `invalid_request`. A rejected update produces one typed error to the sender and no opponent message. All outbound state is detached from registry storage.
+
+## Browser bridge outcome
+
+1. `public/room-client.js` tracks the validated authoritative active match from Pass 02.
+2. It accepts `stacklogic:local-state` only while that match is active, validates the exact state shape defensively, assigns the next local player update sequence, and sends `update_player_state` only through an open existing WebSocket. The local sequence advances only after a successful send. Send failure must not break the local game loop.
+3. It validates `opponent_state` against the active match and exact next opponent sequence, ignores malformed, foreign, duplicate, stale, or skipped updates, and dispatches a detached `stacklogic:opponent-state` event.
+4. A genuinely new validated match resets both per-player counters. Repeated `room_state` delivery for the same match must neither restart the game nor reset counters. Socket close invalidates multiplayer publication. `public/game.js` also dispatches `stacklogic:multiplayer-end` with exact detail `{ matchId }`; `room-client.js` invalidates only when that bounded match ID equals its active authoritative match.
+
+## Game and interface outcome
+
+1. `public/game.js` starts multiplayer through the existing validated match-start seam, retains the authoritative active match ID as the publication owner, and preserves solo Start behavior. Solo Start, Home, and multiplayer game-over invalidate that owner synchronously before reset or any asynchronous prompt/high-score work; late events from an old match cannot publish or render. Invalidation dispatches `stacklogic:multiplayer-end` exactly once for the ending authoritative match.
+2. During multiplayer it dispatches a detached `stacklogic:local-state` snapshot at initial start, after each settled piece lock, and once when game over is entered. On game over the final state event is dispatched before `stacklogic:multiplayer-end`. It does not transmit every movement, rotation, or timer tick.
+3. It validates and renders `stacklogic:opponent-state` into a dedicated miniature opponent canvas using the existing piece colors/theme renderer.
+4. The opponent panel shows opponent name, score, lines, and Playing/Game Over status. It is hidden outside multiplayer and must not alter the accepted lobby or solo layout.
+5. `public/index.html` and `public/style.css` provide an accessible responsive opponent panel: a third compact column on wide screens and a centered panel below the game on narrow screens. Changed `style.css`, `game.js`, and `room-client.js` entry assets retain `v=0.3.0-beta.1` and add the exact revision key `rev=opponent-state-1`.
+
+## Required deterministic gates
+
+- Frozen Pass 03 registry authority test.
+- Frozen Pass 03 protocol relay test.
+- Frozen Pass 03 room-client bridge test.
+- Frozen Pass 03 game/interface event and rendering test.
+- Existing full source suite remains green.
+- Exact candidate paths and hashes are sealed before projection.
+
+## Required canonical-dev browser acceptance
+
+Using two independent concurrent browser contexts on `http://stacklogic-dev.game.lan`:
+
+1. Host creates; guest joins; both Ready; both receive the same authoritative match start.
+2. Both opponent panels become visible and identify the other player.
+3. A hard drop in host produces one settled-board update visible only in guest's opponent panel.
+4. A differently placed hard drop in guest produces one settled-board update visible only in host's opponent panel.
+5. Score/lines/status converge with the corresponding reported opponent state.
+6. Solo Start still works and keeps the opponent panel hidden.
+7. No page exceptions, console errors, failed requests, server errors, or stale cache behavior occur.
+8. Production `stacklogic.game.lan` bytes, process, and route remain unchanged.
+
+## Cumulative subpasses
+
+### 03A — registry state authority
+
+Writable path: `room-registry.js` only. Done when the frozen registry gate and standing regressions pass.
+
+### 03B — protocol acknowledgement and opponent-only relay
+
+Writable path: `room-protocol.js` only. Done when the frozen protocol gate and standing regressions pass against the cumulative 03A state.
+
+### 03C — browser event/WebSocket bridge
+
+Writable path: `public/room-client.js` only. Done when the frozen room-client gate and standing regressions pass against cumulative 03A–03B.
+
+### 03D — game reporting and responsive opponent panel
+
+Writable paths: `public/game.js`, `public/index.html`, and `public/style.css` only. Done when the frozen game/interface gate and the complete unfiltered Pass 03 test file pass against cumulative 03A–03C.
+
+After every accepted subpass, the runner creates a clean cumulative fixture checkpoint. The final unfiltered Pass 03 gate and full source suite are rerun after all subpasses.
+
+## Explicit non-goals
+
+- No garbage, attacks, winner adjudication, results, or rematch.
+- No current falling-piece synchronization.
+- No public matchmaking, spectators, persistence, reconnect recovery, or anti-cheat claim.
+- No disconnect notification, hostile-client rate limiting, or slow-peer queue redesign. The official client emits only initial/lock/game-over snapshots; the existing transport retains its 4096-byte ingress ceiling. Adversarial rate control is a separate pass if the trust boundary expands.
+- No `server.js`, package, release metadata, production, route, certificate, or deployment changes.
+- No push, merge, release, or production promotion without explicit human approval.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "stacklogic-app",
       "version": "0.3.0-beta.1",
       "dependencies": {
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "ws": "8.21.1"
       }
     },
     "node_modules/accepts": {
@@ -822,6 +823,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "node --test tests/**/*.mjs"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "ws": "8.21.1"
   }
 }

--- a/public/game.js
+++ b/public/game.js
@@ -658,6 +658,33 @@ startBtn.addEventListener('click', () => {
   startGame();
 });
 
+// StackLogic match-start handoff seam
+(function() {
+  const startedIds = new Set();
+
+  function isValidMatchStart(detail) {
+    if (!detail || typeof detail !== 'object') return false;
+    var id = detail.id;
+    if (typeof id !== 'string' || id.length < 1 || id.length > 64) return false;
+    if (!/^[A-Za-z0-9_-]+$/.test(id)) return false;
+    var seed = detail.seed;
+    if (typeof seed !== 'number' || !Number.isInteger(seed) || seed < 0 || seed > 0xffffffff) return false;
+    var startedSeq = detail.startedSeq;
+    if (typeof startedSeq !== 'number' || !Number.isInteger(startedSeq) || startedSeq < 1) return false;
+    return true;
+  }
+
+  window.addEventListener('stacklogic:match-start', function(event) {
+    var detail = event.detail;
+    if (!isValidMatchStart(detail)) return;
+    var id = detail.id;
+    var seed = detail.seed;
+    if (startedIds.has(id)) return;
+    startedIds.add(id);
+    startGame(seed);
+  });
+})();
+
 if (previewCheckbox) {
   // Initialize checkbox state from localStorage
   try {

--- a/public/game.js
+++ b/public/game.js
@@ -35,8 +35,20 @@ const titleOverlay = document.getElementById('title');
 const startBtn = document.getElementById('startBtn');
 const highScoresEl = document.getElementById('highScores');
 
+// Opponent panel elements
+const opponentPanel = document.getElementById('opponentPanel');
+const opponentGame = document.getElementById('opponentGame');
+const opponentName = document.getElementById('opponentName');
+const opponentScore = document.getElementById('opponentScore');
+const opponentLines = document.getElementById('opponentLines');
+const opponentStatus = document.getElementById('opponentStatus');
+
 const gameOverOverlay = document.getElementById('gameOver');
 const gameOverText = document.getElementById('gameOverText');
+const gameResultTitle = document.getElementById('gameResultTitle');
+const rematchStatus = document.getElementById('rematchStatus');
+const rematchBtn = document.getElementById('rematchBtn');
+const victoryFireworks = document.getElementById('victoryFireworks');
 const goHomeBtn = document.getElementById('goHomeBtn');
 const pauseMenu = document.getElementById('pauseMenu');
 const pauseResumeBtn = document.getElementById('pauseResumeBtn');
@@ -252,6 +264,12 @@ let nextType = null;
 
 let state; // 'home' | 'playing' | 'paused' | 'gameover'
 
+// Multiplayer owner state (separate from local gameplay state)
+let activeMultiplayerMatchId = null;
+let finishedMultiplayerMatchId = null;
+let rematchCommitted = false;
+let lastRenderedOpponentSeq = 0;
+
 let levelProgressText;
 
 const music = new Audio('assets/stacklogic.mp3');
@@ -460,6 +478,12 @@ function lockPiece() {
 
   clearLines();
   updateHUD();
+
+  // Publish local state after settled lock (before spawn)
+  if (activeMultiplayerMatchId != null) {
+    publishLocalState(false);
+  }
+
   spawn();
 }
 
@@ -534,6 +558,8 @@ function togglePause() {
 }
 
 function goHome() {
+  if (rematchCommitted) return;
+  invalidateOwner();
   state = 'home';
   pauseBtn.textContent = 'Pause';
   portraitPauseBtn.textContent = 'Pause';
@@ -543,12 +569,78 @@ function goHome() {
   resetGameState();
 }
 
+// ---- Multiplayer lifecycle helpers ----
+
+function dispatchStackLogicEvent(type, detail) {
+  const EventConstructor = globalThis.CustomEvent;
+  const event = typeof EventConstructor === 'function'
+    ? new EventConstructor(type, { detail })
+    : { type, detail };
+  window.dispatchEvent(event);
+}
+
+function publishLocalState(gameOver) {
+  if (activeMultiplayerMatchId == null) return;
+  const detachedBoard = cloneMatrix(board);
+  dispatchStackLogicEvent('stacklogic:local-state', {
+    matchId: activeMultiplayerMatchId,
+    board: detachedBoard,
+    score: score,
+    lines: lines,
+    gameOver: !!gameOver
+  });
+}
+
+function getOpponentContext() {
+  if (!opponentGame || typeof opponentGame.getContext !== 'function') return null;
+  return opponentGame.getContext('2d');
+}
+
+function invalidateOwner() {
+  const endingMatchId = activeMultiplayerMatchId;
+  const abandonedMatchId = finishedMultiplayerMatchId;
+  activeMultiplayerMatchId = null;
+  finishedMultiplayerMatchId = null;
+  rematchCommitted = false;
+  lastRenderedOpponentSeq = 0;
+
+  // Clear every multiplayer-only visual/action surface even after a finished match.
+  const octx = getOpponentContext();
+  if (octx) octx.clearRect(0, 0, opponentGame.width, opponentGame.height);
+  if (opponentName) opponentName.textContent = '—';
+  if (opponentScore) opponentScore.textContent = '0';
+  if (opponentLines) opponentLines.textContent = '0';
+  if (opponentStatus) opponentStatus.textContent = '';
+  if (opponentPanel) opponentPanel.hidden = true;
+  if (victoryFireworks) victoryFireworks.hidden = true;
+  if (rematchStatus) rematchStatus.textContent = '';
+  if (rematchBtn) {
+    rematchBtn.disabled = true;
+    rematchBtn.textContent = 'Rematch';
+  }
+
+  // Dispatch only when an active multiplayer owner actually ended.
+  if (endingMatchId != null) {
+    dispatchStackLogicEvent('stacklogic:multiplayer-end', { matchId: endingMatchId });
+  } else if (abandonedMatchId != null) {
+    dispatchStackLogicEvent('stacklogic:multiplayer-abandon', { matchId: abandonedMatchId });
+  }
+}
+
 function triggerGameOver(reason) {
   if (state === 'gameover') return;
   state = 'gameover';
   hideOverlay(pauseMenu);
   stopMusic();
   setStatus('Game Over');
+  // A multiplayer loss waits for the server-authoritative result. Do not run the
+  // solo high-score/home flow or fence the result bridge before it arrives.
+  if (activeMultiplayerMatchId != null) {
+    setStatus('Match result pending…');
+    publishLocalState(true);
+    return;
+  }
+
   showGameOver('Game Over');
 
   // Freeze input immediately. Async flow runs after.
@@ -572,6 +664,9 @@ function triggerGameOver(reason) {
 }
 
 function startGame(seed = createSoloSeed()) {
+  if (rematchCommitted) return;
+  // Solo Start clears both active and completed multiplayer ownership/UI.
+  invalidateOwner();
   hideHome();
   hideOverlay(gameOverOverlay);
   hideOverlay(pauseMenu);
@@ -654,6 +749,15 @@ goHomeBtn.addEventListener('click', () => {
   goHome();
 });
 
+if (rematchBtn) rematchBtn.addEventListener('click', () => {
+  if (rematchBtn.disabled) return;
+  rematchCommitted = true;
+  rematchBtn.disabled = true;
+  rematchBtn.textContent = 'Waiting for opponent…';
+  if (rematchStatus) rematchStatus.textContent = 'Waiting for opponent to accept Rematch.';
+  dispatchStackLogicEvent('stacklogic:rematch-request', { matchId: finishedMultiplayerMatchId });
+});
+
 startBtn.addEventListener('click', () => {
   startGame();
 });
@@ -681,8 +785,173 @@ startBtn.addEventListener('click', () => {
     var seed = detail.seed;
     if (startedIds.has(id)) return;
     startedIds.add(id);
-    startGame(seed);
+
+    // If a different game-side owner is active, invalidate that old owner exactly once
+    if (activeMultiplayerMatchId != null && activeMultiplayerMatchId !== id) {
+      invalidateOwner();
+    }
+
+    // Activate the new bounded match ID and reset opponent sequence to 0
+    activeMultiplayerMatchId = id;
+    finishedMultiplayerMatchId = null;
+    rematchCommitted = false;
+    if (rematchStatus) rematchStatus.textContent = '';
+    lastRenderedOpponentSeq = 0;
+
+    // Start the seeded game through the existing start seam
+    hideHome();
+    hideOverlay(gameOverOverlay);
+    hideOverlay(pauseMenu);
+    resetGameState(seed);
+    state = 'playing';
+    pauseBtn.textContent = 'Pause';
+    portraitPauseBtn.textContent = 'Pause';
+    startMusic();
+
+    // Reveal and reset the opponent panel with status exactly "Waiting for opponent"
+    if (opponentName) opponentName.textContent = '—';
+    if (opponentScore) opponentScore.textContent = '0';
+    if (opponentLines) opponentLines.textContent = '0';
+    if (opponentStatus) opponentStatus.textContent = 'Waiting for opponent';
+    const octx = getOpponentContext();
+    if (octx) octx.clearRect(0, 0, opponentGame.width, opponentGame.height);
+    if (opponentPanel) opponentPanel.hidden = false;
+
+    // Dispatch exactly one initial local snapshot
+    publishLocalState(false);
   });
+})();
+
+window.addEventListener('stacklogic:match-result', (event) => {
+  const detail = event?.detail;
+  if (!detail || detail.matchId !== activeMultiplayerMatchId || typeof detail.didWin !== 'boolean') return;
+  state = 'gameover';
+  stopMusic();
+  hideOverlay(pauseMenu);
+  if (gameResultTitle) gameResultTitle.textContent = detail.didWin ? 'Victory!' : 'Defeat';
+  if (gameOverText) gameOverText.textContent = detail.didWin ? 'You won the round!' : `${detail.winnerName || 'Your opponent'} won the round.`;
+  if (victoryFireworks) victoryFireworks.hidden = !detail.didWin;
+  if (rematchStatus) rematchStatus.textContent = 'Choose Rematch to play another round.';
+  if (rematchBtn) { rematchBtn.disabled = false; rematchBtn.textContent = 'Rematch'; }
+  if (!detail.didWin && opponentStatus) opponentStatus.textContent = `${detail.winnerName || 'Opponent'} wins! ✦`;
+  finishedMultiplayerMatchId = detail.matchId;
+  rematchCommitted = false;
+  activeMultiplayerMatchId = null;
+  showOverlay(gameOverOverlay);
+  if (rematchBtn && typeof rematchBtn.focus === 'function') rematchBtn.focus();
+});
+
+window.addEventListener('stacklogic:rematch-status', (event) => {
+  const detail = event?.detail;
+  if (!detail || detail.matchId !== finishedMultiplayerMatchId || !Array.isArray(detail.acceptedPlayerIds) || !rematchBtn) return;
+  if (rematchBtn.disabled) return;
+  if (detail.acceptedPlayerIds.length === 0) {
+    rematchBtn.textContent = 'Rematch';
+    if (rematchStatus) rematchStatus.textContent = 'Choose Rematch to play another round.';
+    return;
+  }
+  rematchBtn.textContent = 'Opponent ready — Rematch';
+  if (rematchStatus) rematchStatus.textContent = 'Opponent accepted. Choose Rematch to start the next round.';
+});
+
+// ---- Opponent state event handler ----
+(function() {
+  const VALID_PIECES = new Set(['I', 'O', 'T', 'S', 'Z', 'J', 'L']);
+  const SAFE_INT_MAX = 1_000_000_000;
+
+  function isSafeInt(n) {
+    return typeof n === 'number' && Number.isInteger(n) && n >= 0 && n <= SAFE_INT_MAX;
+  }
+
+  function isValidOpponentBoard(board) {
+    if (!Array.isArray(board) || board.length !== 20) return false;
+    for (let y = 0; y < 20; y++) {
+      const row = board[y];
+      if (!Array.isArray(row) || row.length !== 10) return false;
+      for (let x = 0; x < 10; x++) {
+        const cell = row[x];
+        if (cell !== null && !VALID_PIECES.has(cell)) return false;
+      }
+    }
+    return true;
+  }
+
+  function handleOpponentState(event) {
+    try {
+      // Must be a non-null object with exactly own enumerable keys matchId, opponent
+      var detail = event.detail;
+      if (!detail || typeof detail !== 'object') return;
+      var ownKeys = Object.keys(detail);
+      if (ownKeys.length !== 2 || !Object.hasOwn(detail, 'matchId') || !Object.hasOwn(detail, 'opponent')) return;
+
+      var matchId = detail.matchId;
+      if (typeof matchId !== 'string' || !/^[A-Za-z0-9_-]{1,64}$/.test(matchId)) return;
+
+      // A game-side multiplayer owner must be active and match
+      if (activeMultiplayerMatchId == null || activeMultiplayerMatchId !== matchId) return;
+
+      var opponent = detail.opponent;
+      if (!opponent || typeof opponent !== 'object') return;
+      var oppKeys = Object.keys(opponent);
+      if (oppKeys.length !== 6 || !Object.hasOwn(opponent, 'name') || !Object.hasOwn(opponent, 'updateSeq') ||
+          !Object.hasOwn(opponent, 'board') || !Object.hasOwn(opponent, 'score') || !Object.hasOwn(opponent, 'lines') ||
+          !Object.hasOwn(opponent, 'gameOver')) return;
+
+      var name = opponent.name;
+      if (typeof name !== 'string' || name.length < 1 || name.length > 24) return;
+
+      var updateSeq = opponent.updateSeq;
+      if (typeof updateSeq !== 'number' || !Number.isSafeInteger(updateSeq) || updateSeq < 1 || updateSeq > SAFE_INT_MAX) return;
+
+      // Must equal last-rendered sequence plus one
+      if (updateSeq !== lastRenderedOpponentSeq + 1) return;
+
+      var oppBoard = opponent.board;
+      if (!isValidOpponentBoard(oppBoard)) return;
+
+      var oppScore = opponent.score;
+      if (!isSafeInt(oppScore)) return;
+
+      var oppLines = opponent.lines;
+      if (!isSafeInt(oppLines)) return;
+
+      var gameOver = opponent.gameOver;
+      if (typeof gameOver !== 'boolean') return;
+
+      // All validation passed - render
+      // Clear the complete 120 x 240 opponent canvas
+      const octx = getOpponentContext();
+      if (octx) {
+        octx.clearRect(0, 0, opponentGame.width, opponentGame.height);
+
+        // Draw each occupied cell
+        var themeId = (typeof window !== 'undefined' && window.ThemeModule && window.ThemeModule.getCurrentTheme)
+          ? window.ThemeModule.getCurrentTheme() : 'Default';
+
+        for (let y = 0; y < 20; y++) {
+          for (let x = 0; x < 10; x++) {
+            const cellType = oppBoard[y][x];
+            if (cellType) {
+              drawBrickAt(octx, x * 12, y * 12, COLORS[cellType], themeId, 12);
+            }
+          }
+        }
+      }
+
+      // Set name, score, lines, and status through textContent
+      if (opponentName) opponentName.textContent = name;
+      if (opponentScore) opponentScore.textContent = String(oppScore);
+      if (opponentLines) opponentLines.textContent = String(oppLines);
+      if (opponentStatus) opponentStatus.textContent = gameOver ? 'Game Over' : 'Playing';
+
+      // Advance last-rendered sequence only after complete validation/rendering
+      lastRenderedOpponentSeq = updateSeq;
+    } catch (e) {
+      // Non-throwing: invalid events do not advance sequence, alter text, or draw
+    }
+  }
+
+  window.addEventListener('stacklogic:opponent-state', handleOpponentState);
 })();
 
 if (previewCheckbox) {

--- a/public/index.html
+++ b/public/index.html
@@ -63,11 +63,16 @@
 
             <button id="startBtn" class="btn primary" type="button">Play Solo</button>
 
-            <div class="multiplayer-section">
-              <button id="createMatchBtn" class="btn" type="button" disabled aria-describedby="createMatchHint">Create Match</button>
-              <span id="createMatchHint" class="coming-soon-hint">Coming Soon</span>
-              <button id="joinMatchBtn" class="btn" type="button" disabled aria-describedby="joinMatchHint">Join Match</button>
-              <span id="joinMatchHint" class="coming-soon-hint">Coming Soon</span>
+            <div id="multiplayerLobby" class="multiplayer-section">
+              <input id="roomName" type="text" placeholder="Your name" aria-label="Player name" />
+              <input id="roomCode" type="text" placeholder="Room code" aria-label="Room code" />
+              <button id="createMatchBtn" class="btn" type="button">Create Match</button>
+              <button id="joinMatchBtn" class="btn" type="button">Join Match</button>
+              <div id="roomStatus" class="status" aria-live="polite"></div>
+              <div id="roomPlayers" class="players-list" aria-live="polite"></div>
+              <button id="roomReadyBtn" class="btn primary" type="button">Ready</button>
+              <button id="copyCodeBtn" class="btn" type="button" disabled>Copy Code</button>
+              <button id="copyInviteLinkBtn" class="btn" type="button" disabled>Copy Invite Link</button>
             </div>
 
             <div class="setting">
@@ -131,5 +136,6 @@
     <script src="theme.js?v=0.3.0-beta.1"></script>
     <script src="theme-renderer.js?v=0.3.0-beta.1"></script>
     <script type="module" src="game.js?v=0.3.0-beta.1"></script>
+    <script type="module" src="room-client.js?v=0.3.0-beta.1&rev=room-lobby-1"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <title>Stacklogic</title>
     <meta name="description" content="Stacklogic, a falling block game." />
     <link rel="icon" href="data:," />
-    <link rel="stylesheet" href="style.css?v=0.3.0-beta.1" />
+    <link rel="stylesheet" href="style.css?v=0.3.0-beta.1&rev=opponent-state-1" />
   </head>
   <body>
     <main class="wrap">
@@ -109,11 +109,14 @@
           </div>
         </div>
 
-        <div id="gameOver" class="overlay">
-          <div class="card">
-            <h2 class="title">Game Over</h2>
-            <p class="hint" id="gameOverText">Your game has ended.</p>
-            <button id="goHomeBtn" class="btn primary" type="button">Home</button>
+        <div id="gameOver" class="overlay" role="dialog" aria-modal="true" aria-labelledby="gameResultTitle">
+          <div class="card result-card">
+            <div id="victoryFireworks" class="victory-fireworks" hidden aria-hidden="true">✦ ✷ ✦</div>
+            <h2 id="gameResultTitle" class="title" aria-live="assertive">Game Over</h2>
+            <p class="hint" id="gameOverText" aria-live="polite">Your game has ended.</p>
+            <p id="rematchStatus" class="hint" aria-live="polite"></p>
+            <button id="rematchBtn" class="btn primary" type="button" disabled>Rematch</button>
+            <button id="goHomeBtn" class="btn" type="button">Home</button>
           </div>
         </div>
 
@@ -131,11 +134,22 @@
 
         <div class="mobile-status" id="statusMobile"></div>
       </div>
+
+      <aside id="opponentPanel" class="opponent-panel" hidden aria-labelledby="opponentHeading">
+        <h2 id="opponentHeading" class="opp-heading">Opponent</h2>
+        <canvas id="opponentGame" width="120" height="240" aria-label="Opponent game board"></canvas>
+        <div class="opp-info">
+          <div class="row"><span>Name</span><span id="opponentName">—</span></div>
+          <div class="row"><span>Score</span><span id="opponentScore">0</span></div>
+          <div class="row"><span>Lines</span><span id="opponentLines">0</span></div>
+        </div>
+        <p id="opponentStatus" class="opp-status" aria-live="polite"></p>
+      </aside>
     </main>
 
     <script src="theme.js?v=0.3.0-beta.1"></script>
     <script src="theme-renderer.js?v=0.3.0-beta.1"></script>
-    <script type="module" src="game.js?v=0.3.0-beta.1"></script>
-    <script type="module" src="room-client.js?v=0.3.0-beta.1&rev=room-lobby-1"></script>
+    <script type="module" src="game.js?v=0.3.0-beta.1&rev=opponent-state-1"></script>
+    <script type="module" src="room-client.js?v=0.3.0-beta.1&rev=opponent-state-1"></script>
   </body>
 </html>

--- a/public/room-client.js
+++ b/public/room-client.js
@@ -1,0 +1,155 @@
+const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+const wsUrl = `${wsProtocol}//${window.location.host}/ws`;
+const ws = new WebSocket(wsUrl);
+
+let currentSeq = null;
+let selfPlayerId = null;
+let roomState = null;
+
+const els = {
+  roomName: document.getElementById('roomName'),
+  roomCode: document.getElementById('roomCode'),
+  createBtn: document.getElementById('createMatchBtn'),
+  joinBtn: document.getElementById('joinMatchBtn'),
+  status: document.getElementById('roomStatus'),
+  players: document.getElementById('roomPlayers'),
+  readyBtn: document.getElementById('roomReadyBtn'),
+  copyCodeBtn: document.getElementById('copyCodeBtn'),
+  copyInviteLinkBtn: document.getElementById('copyInviteLinkBtn')
+};
+
+async function copyText(text) {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    try { await navigator.clipboard.writeText(text); return true; } catch { return false; }
+  }
+  let ta = null;
+  try {
+    ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    return !!document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    if (ta && ta.parentNode) { ta.parentNode.removeChild(ta); }
+  }
+}
+
+function setStatus(msg) { els.status.textContent = msg; }
+function updatePlayerList(room) {
+  if (!room || !room.players) { els.players.textContent = ''; return; }
+  els.players.textContent = '';
+  room.players.forEach(p => {
+    const div = document.createElement('div');
+    div.textContent = `${p.name} (${p.ready ? 'Ready' : 'Not ready'})`;
+    els.players.appendChild(div);
+  });
+}
+function updateReadyBtn() {
+  if (!selfPlayerId || currentSeq === null) { els.readyBtn.disabled = true; els.readyBtn.textContent = 'Ready'; return; }
+  const self = roomState?.players?.find(p => p.id === selfPlayerId);
+  const ready = self ? self.ready : false;
+  els.readyBtn.disabled = false;
+  els.readyBtn.textContent = ready ? 'Unready' : 'Ready';
+}
+
+function generateRequestId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const array = new Uint8Array(16);
+    crypto.getRandomValues(array);
+    const hex = Array.from(array).map(b => b.toString(16).padStart(2, '0')).join('');
+    return hex.substring(0, 32);
+  }
+
+  throw new Error('Secure random ID generation not available');
+}
+
+function sendMsg(type, payload) {
+  let id;
+  try {
+    id = generateRequestId();
+  } catch (e) {
+    setStatus('Error: Secure ID generation failed');
+    return;
+  }
+  ws.send(JSON.stringify({ type, requestId: id, ...payload }));
+}
+
+function normalizeRoomCode(code) {
+  return code.replace(/[\s-]/g, '').toUpperCase();
+}
+
+const params = new URLSearchParams(window.location.search);
+const rawPrefill = params.get('room');
+let prefilledRoom = '';
+if (rawPrefill) {
+  const urlMatch = rawPrefill.match(/[?&]room=([^&]+)/);
+  if (urlMatch) {
+    const usp = new URLSearchParams(urlMatch[0]);
+    prefilledRoom = normalizeRoomCode(usp.get('room'));
+  } else {
+    prefilledRoom = normalizeRoomCode(rawPrefill);
+  }
+}
+if (prefilledRoom) els.roomCode.value = prefilledRoom;
+ws.addEventListener('open', () => setStatus('Connected to lobby.'));
+ws.addEventListener('message', (e) => {
+  let data;
+  try { data = JSON.parse(e.data); } catch { return; }
+  if (data.type === 'room_state') {
+    currentSeq = data.room.seq; selfPlayerId = data.self.playerId; roomState = data.room;
+    updatePlayerList(data.room); updateReadyBtn(); setStatus(`Room ${data.room.code} active.`);
+    els.roomCode.value = normalizeRoomCode(data.room.code);
+    els.copyCodeBtn.disabled = false;
+    els.copyInviteLinkBtn.disabled = false;
+  } else if (data.type === 'error') setStatus(`Error: ${data.code}`);
+});
+ws.addEventListener('error', () => setStatus('Connection error.'));
+ws.addEventListener('close', () => setStatus('Disconnected.'));
+els.createBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); if (name) sendMsg('create_room', { name }); });
+els.joinBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); const rawCode = els.roomCode.value.trim(); const code = normalizeRoomCode(rawCode); if (name && code) sendMsg('join_room', { code, name }); });
+els.roomCode.addEventListener('paste', async (e) => {
+  const text = e.clipboardData.getData('text');
+  try {
+    const url = new URL(text);
+    const roomParam = url.searchParams.get('room');
+    if (roomParam) {
+      e.preventDefault();
+      els.roomCode.value = normalizeRoomCode(roomParam);
+    }
+  } catch { /* not a valid URL, ignore */ }
+});
+els.readyBtn.addEventListener('click', () => {
+  if (!selfPlayerId || currentSeq === null) return;
+  const self = roomState?.players?.find(p => p.id === selfPlayerId);
+  sendMsg('set_ready', { ready: self ? !self.ready : false, expectedSeq: currentSeq });
+  updateReadyBtn();
+});
+
+els.copyCodeBtn.addEventListener('click', async () => {
+  const normalized = roomState ? normalizeRoomCode(roomState.code) : '';
+  if (await copyText(normalized)) {
+    setStatus(`Copied code: ${normalized}`);
+  } else {
+    setStatus('Failed to copy code.');
+  }
+});
+
+els.copyInviteLinkBtn.addEventListener('click', async () => {
+  const normalized = roomState ? normalizeRoomCode(roomState.code) : '';
+  const url = window.location.origin + window.location.pathname + '?room=' + normalized;
+  if (await copyText(url)) {
+    setStatus('Copied invite link.');
+  } else {
+    setStatus('Failed to copy invite link.');
+  }
+});
+
+updateReadyBtn();

--- a/public/room-client.js
+++ b/public/room-client.js
@@ -6,6 +6,10 @@ let currentSeq = null;
 let selfPlayerId = null;
 let roomState = null;
 let dispatchedMatchIds = new Set();
+let activeMatchId = null;
+let finishedMatchId = null;
+let localUpdateSeq = 0;
+let opponentUpdateSeq = 0;
 
 const els = {
   roomName: document.getElementById('roomName'),
@@ -78,13 +82,45 @@ function sendMsg(type, payload) {
     id = generateRequestId();
   } catch (e) {
     setStatus('Error: Secure ID generation failed');
-    return;
+    return false;
   }
-  ws.send(JSON.stringify({ type, requestId: id, ...payload }));
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  try {
+    ws.send(JSON.stringify({ type, requestId: id, ...payload }));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeRoomCode(code) {
   return code.replace(/[\s-]/g, '').toUpperCase();
+}
+
+const VALID_CELLS = new Set(['I', 'O', 'T', 'S', 'Z', 'J', 'L']);
+
+function isValidState(state) {
+  if (!state || typeof state !== 'object') return false;
+  const keys = Object.keys(state);
+  if (keys.length !== 4) return false;
+  if (!Object.hasOwn(state, 'board') || !Object.hasOwn(state, 'score') || !Object.hasOwn(state, 'lines') || !Object.hasOwn(state, 'gameOver')) return false;
+  const board = state.board;
+  if (!Array.isArray(board) || board.length !== 20) return false;
+  for (let r = 0; r < 20; r++) {
+    const row = board[r];
+    if (!Array.isArray(row) || row.length !== 10) return false;
+    for (let c = 0; c < 10; c++) {
+      const cell = row[c];
+      if (cell !== null && !VALID_CELLS.has(cell)) return false;
+    }
+  }
+  const score = state.score;
+  if (typeof score !== 'number' || !Number.isSafeInteger(score) || score < 0 || score > 1_000_000_000) return false;
+  const lines = state.lines;
+  if (typeof lines !== 'number' || !Number.isSafeInteger(lines) || lines < 0 || lines > 1_000_000_000) return false;
+  const gameOver = state.gameOver;
+  if (typeof gameOver !== 'boolean') return false;
+  return true;
 }
 
 function isValidMatch(match, seq) {
@@ -106,11 +142,21 @@ function handleMatchSnapshot(match, seq) {
     return;
   }
   dispatchedMatchIds.add(matchId);
+  activeMatchId = matchId;
+  finishedMatchId = null;
+  localUpdateSeq = 0;
+  opponentUpdateSeq = 0;
   els.readyBtn.disabled = true;
   els.readyBtn.textContent = 'Started';
   window.dispatchEvent(new CustomEvent('stacklogic:match-start', {
     detail: { id: match.id, seed: match.seed, startedSeq: match.startedSeq }
   }));
+}
+
+function invalidateActiveMatch() {
+  activeMatchId = null;
+  localUpdateSeq = 0;
+  opponentUpdateSeq = 0;
 }
 
 const params = new URLSearchParams(window.location.search);
@@ -130,6 +176,7 @@ ws.addEventListener('open', () => setStatus('Connected to lobby.'));
 ws.addEventListener('message', (e) => {
   let data;
   try { data = JSON.parse(e.data); } catch { return; }
+  if (!data || typeof data !== 'object') return;
   if (data.type === 'room_state') {
     currentSeq = data.room.seq; selfPlayerId = data.self.playerId; roomState = data.room;
     updatePlayerList(data.room); updateReadyBtn(); setStatus(`Room ${data.room.code} active.`);
@@ -138,9 +185,52 @@ ws.addEventListener('message', (e) => {
     els.copyInviteLinkBtn.disabled = false;
     handleMatchSnapshot(data.room.match, currentSeq);
   } else if (data.type === 'error') setStatus(`Error: ${data.code}`);
+  else if (data.type === 'opponent_state') {
+    const msgKeys = Object.keys(data);
+    if (msgKeys.length !== 4) return;
+    if (!Object.hasOwn(data, 'type') || !Object.hasOwn(data, 'protocolVersion') || !Object.hasOwn(data, 'matchId') || !Object.hasOwn(data, 'opponent')) return;
+    if (data.protocolVersion !== 1) return;
+    if (!activeMatchId || data.matchId !== activeMatchId) return;
+    const opp = data.opponent;
+    if (!opp || typeof opp !== 'object') return;
+    const oppKeys = Object.keys(opp);
+    if (oppKeys.length !== 6) return;
+    if (!Object.hasOwn(opp, 'name') || !Object.hasOwn(opp, 'updateSeq') || !Object.hasOwn(opp, 'board') || !Object.hasOwn(opp, 'score') || !Object.hasOwn(opp, 'lines') || !Object.hasOwn(opp, 'gameOver')) return;
+    const oppName = opp.name;
+    const otherPlayer = roomState?.players?.find(p => p.id !== selfPlayerId);
+    if (!otherPlayer || otherPlayer.name !== oppName) return;
+    const uSeq = opp.updateSeq;
+    if (typeof uSeq !== 'number' || !Number.isSafeInteger(uSeq) || uSeq < 1 || uSeq > 1_000_000_000) return;
+    if (uSeq !== opponentUpdateSeq + 1) return;
+    const extractedState = { board: opp.board, score: opp.score, lines: opp.lines, gameOver: opp.gameOver };
+    if (!isValidState(extractedState)) return;
+    const detachedDetail = {
+      matchId: data.matchId,
+      opponent: { name: opp.name, updateSeq: opp.updateSeq, board: extractedState.board.map(row => row.slice()), score: extractedState.score, lines: extractedState.lines, gameOver: extractedState.gameOver }
+    };
+    opponentUpdateSeq = uSeq;
+    window.dispatchEvent(new CustomEvent('stacklogic:opponent-state', { detail: detachedDetail }));
+  } else if (data.type === 'match_result') {
+    const keys = Object.keys(data);
+    if (keys.length !== 5 || !Object.hasOwn(data, 'type') || !Object.hasOwn(data, 'protocolVersion') || !Object.hasOwn(data, 'matchId') || !Object.hasOwn(data, 'winnerId') || !Object.hasOwn(data, 'loserId')) return;
+    if (!activeMatchId || data.protocolVersion !== 1 || data.matchId !== activeMatchId || typeof data.winnerId !== 'string' || typeof data.loserId !== 'string' || data.winnerId === data.loserId) return;
+    const winner = roomState?.players?.find((p) => p.id === data.winnerId);
+    const loser = roomState?.players?.find((p) => p.id === data.loserId);
+    if (!winner || !loser || !selfPlayerId || (selfPlayerId !== data.winnerId && selfPlayerId !== data.loserId)) return;
+    finishedMatchId = activeMatchId;
+    invalidateActiveMatch();
+    window.dispatchEvent(new CustomEvent('stacklogic:match-result', { detail: { matchId: data.matchId, didWin: data.winnerId === selfPlayerId, winnerName: winner.name } }));
+  } else if (data.type === 'rematch_status') {
+    const keys = Object.keys(data);
+    if (keys.length !== 4 || !Object.hasOwn(data, 'type') || !Object.hasOwn(data, 'protocolVersion') || !Object.hasOwn(data, 'matchId') || !Object.hasOwn(data, 'acceptedPlayerIds')) return;
+    if (data.protocolVersion !== 1 || data.matchId !== finishedMatchId || !Array.isArray(data.acceptedPlayerIds)) return;
+    const players = roomState?.players || [];
+    if (data.acceptedPlayerIds.length > players.length || new Set(data.acceptedPlayerIds).size !== data.acceptedPlayerIds.length || data.acceptedPlayerIds.some((id) => typeof id !== 'string' || !players.some((player) => player.id === id))) return;
+    window.dispatchEvent(new CustomEvent('stacklogic:rematch-status', { detail: { matchId: data.matchId, acceptedPlayerIds: data.acceptedPlayerIds.slice() } }));
+  }
 });
 ws.addEventListener('error', () => setStatus('Connection error.'));
-ws.addEventListener('close', () => setStatus('Disconnected.'));
+ws.addEventListener('close', () => { invalidateActiveMatch(); setStatus('Disconnected.'); });
 els.createBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); if (name) sendMsg('create_room', { name }); });
 els.joinBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); const rawCode = els.roomCode.value.trim(); const code = normalizeRoomCode(rawCode); if (name && code) sendMsg('join_room', { code, name }); });
 els.roomCode.addEventListener('paste', async (e) => {
@@ -178,6 +268,47 @@ els.copyInviteLinkBtn.addEventListener('click', async () => {
   } else {
     setStatus('Failed to copy invite link.');
   }
+});
+
+window.addEventListener('stacklogic:multiplayer-end', (event) => {
+  if (!activeMatchId) return;
+  const detail = event.detail;
+  if (!detail || typeof detail !== 'object') return;
+  const keys = Object.keys(detail);
+  if (keys.length !== 1 || !Object.hasOwn(detail, 'matchId')) return;
+  const detailMatchId = detail.matchId;
+  if (typeof detailMatchId !== 'string') return;
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(detailMatchId)) return;
+  if (detailMatchId !== activeMatchId) return;
+  invalidateActiveMatch();
+});
+
+window.addEventListener('stacklogic:multiplayer-abandon', (event) => {
+  const matchId = event?.detail?.matchId;
+  if (matchId && matchId === finishedMatchId) finishedMatchId = null;
+});
+
+window.addEventListener('stacklogic:rematch-request', (event) => {
+  const matchId = event?.detail?.matchId;
+  if (matchId && matchId === finishedMatchId) sendMsg('request_rematch', { matchId });
+});
+
+window.addEventListener('stacklogic:local-state', (event) => {
+  if (!activeMatchId || !ws) return;
+  const detail = event.detail;
+  if (!detail || typeof detail !== 'object') return;
+  const keys = Object.keys(detail);
+  if (keys.length !== 5) return;
+  if (!Object.hasOwn(detail, 'matchId') || !Object.hasOwn(detail, 'board') || !Object.hasOwn(detail, 'score') || !Object.hasOwn(detail, 'lines') || !Object.hasOwn(detail, 'gameOver')) return;
+  const detailMatchId = event.detail.matchId;
+  if (detailMatchId !== activeMatchId) return;
+  const extractedState = { board: event.detail.board, score: event.detail.score, lines: event.detail.lines, gameOver: event.detail.gameOver };
+  if (!isValidState(extractedState)) return;
+  if (localUpdateSeq >= 1_000_000_000) return;
+  const nextSeq = localUpdateSeq + 1;
+  const detachedState = { board: extractedState.board.map(row => row.slice()), score: extractedState.score, lines: extractedState.lines, gameOver: extractedState.gameOver };
+  const sent = sendMsg('update_player_state', { matchId: activeMatchId, updateSeq: nextSeq, state: detachedState });
+  if (sent) localUpdateSeq = nextSeq;
 });
 
 updateReadyBtn();

--- a/public/room-client.js
+++ b/public/room-client.js
@@ -5,6 +5,7 @@ const ws = new WebSocket(wsUrl);
 let currentSeq = null;
 let selfPlayerId = null;
 let roomState = null;
+let dispatchedMatchIds = new Set();
 
 const els = {
   roomName: document.getElementById('roomName'),
@@ -86,6 +87,32 @@ function normalizeRoomCode(code) {
   return code.replace(/[\s-]/g, '').toUpperCase();
 }
 
+function isValidMatch(match, seq) {
+  if (!match || typeof match !== 'object') return false;
+  if (typeof match.id !== 'string' || match.id.length < 1 || match.id.length > 64) return false;
+  if (!/^[A-Za-z0-9_-]+$/.test(match.id)) return false;
+  if (typeof match.seed !== 'number' || !Number.isInteger(match.seed) || match.seed < 0 || match.seed > 0xffffffff) return false;
+  if (typeof match.startedSeq !== 'number' || !Number.isInteger(match.startedSeq) || match.startedSeq < 1) return false;
+  if (match.startedSeq !== seq) return false;
+  return true;
+}
+
+function handleMatchSnapshot(match, seq) {
+  if (!isValidMatch(match, seq)) return;
+  const matchId = match.id;
+  if (dispatchedMatchIds.has(matchId)) {
+    els.readyBtn.disabled = true;
+    els.readyBtn.textContent = 'Started';
+    return;
+  }
+  dispatchedMatchIds.add(matchId);
+  els.readyBtn.disabled = true;
+  els.readyBtn.textContent = 'Started';
+  window.dispatchEvent(new CustomEvent('stacklogic:match-start', {
+    detail: { id: match.id, seed: match.seed, startedSeq: match.startedSeq }
+  }));
+}
+
 const params = new URLSearchParams(window.location.search);
 const rawPrefill = params.get('room');
 let prefilledRoom = '';
@@ -109,6 +136,7 @@ ws.addEventListener('message', (e) => {
     els.roomCode.value = normalizeRoomCode(data.room.code);
     els.copyCodeBtn.disabled = false;
     els.copyInviteLinkBtn.disabled = false;
+    handleMatchSnapshot(data.room.match, currentSeq);
   } else if (data.type === 'error') setStatus(`Error: ${data.code}`);
 });
 ws.addEventListener('error', () => setStatus('Connection error.'));

--- a/public/style.css
+++ b/public/style.css
@@ -6,6 +6,21 @@
   --border: #283244;
 }
 
+.victory-fireworks {
+  margin: 0 0 10px;
+  color: #ffd43b;
+  font-size: 2rem;
+  letter-spacing: .4rem;
+  text-shadow: 0 0 12px #ff7b00, 0 0 24px #ff4d8d;
+  pointer-events: none;
+  animation: victory-spark 1.2s ease-in-out infinite alternate;
+}
+
+@keyframes victory-spark {
+  from { transform: scale(.9); opacity: .72; }
+  to { transform: scale(1.08); opacity: 1; }
+}
+
 /* Theme: Default */
 [data-theme="Default"] {
   --bg: #0b0f14;
@@ -81,12 +96,57 @@ body {
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 220px 300px 160px;
   gap: 16px;
   padding: 16px;
   max-width: 760px;
   margin: 0 auto;
   align-items: start;
+}
+
+.opponent-panel {
+  width: 160px;
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.opp-heading {
+  margin: 0 0 8px;
+  font-size: 15px;
+  text-align: center;
+}
+
+.opponent-panel canvas#opponentGame {
+  display: block;
+  width: 120px;
+  height: 240px;
+  margin: 0 auto 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+
+.opp-info {
+  margin-top: 8px;
+}
+
+.opp-info .row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px solid #1e2736;
+  font-size: 12px;
+}
+
+.opp-status {
+  margin-top: 8px;
+  min-height: 16px;
+  color: #ffb4a2;
+  font-size: 12px;
+  text-align: center;
+}
+
+.opponent-panel[hidden] {
+  display: none;
 }
 
 .stage {
@@ -383,6 +443,10 @@ canvas#game {
   canvas#game {
     margin: 0 auto;
   }
+  .opponent-panel {
+    grid-column: 1;
+    justify-self: center;
+  }
   .mobile-controls {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -489,10 +553,14 @@ canvas#game {
 
 /* Reduced motion guard */
 @media (prefers-reduced-motion: reduce) {
-  /* Disable any ambient animation classes or transitions */
+  /* Disable any ambient animation classes or transitions. */
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .victory-fireworks {
+    animation: none !important;
   }
 }

--- a/room-code.js
+++ b/room-code.js
@@ -55,7 +55,7 @@ function normalizePlayerName(name) {
   const collapsed = trimmed.replace(/[\t \r\n\f\v]+/g, " ");
 
   // Check allowed characters: ASCII letters, digits, space, underscore, hyphen
-  if (!/^[\p{L}\p{N} _-]+$/u.test(collapsed)) {
+  if (!/^[A-Za-z0-9 _-]+$/.test(collapsed)) {
     const err = new Error("invalid name");
     err.code = "invalid_name";
     throw err;

--- a/room-code.js
+++ b/room-code.js
@@ -1,6 +1,8 @@
+import { randomBytes } from "node:crypto";
+
 const ROOM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
-function generateRoomCode(randomBytesFn) {
+function generateRoomCode(randomBytesFn = randomBytes) {
   if (typeof randomBytesFn !== "function") {
     const err = new Error("invalid entropy");
     err.code = "invalid_entropy";

--- a/room-code.js
+++ b/room-code.js
@@ -1,0 +1,72 @@
+const ROOM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+function generateRoomCode(randomBytesFn) {
+  if (typeof randomBytesFn !== "function") {
+    const err = new Error("invalid entropy");
+    err.code = "invalid_entropy";
+    throw err;
+  }
+  const result = randomBytesFn(6);
+  if (
+    !result ||
+    typeof result !== "object" ||
+    !Number.isInteger(result.length) ||
+    result.length < 6
+  ) {
+    const err = new Error("invalid entropy");
+    err.code = "invalid_entropy";
+    throw err;
+  }
+  // Verify it behaves like Uint8Array (has byteLength, Symbol.toStringTag, and is unsigned)
+  if (!("byteLength" in result) || typeof result[Symbol.toStringTag] !== "string") {
+    const err = new Error("invalid entropy");
+    err.code = "invalid_entropy";
+    throw err;
+  }
+  // Ensure it's Uint8Array-compatible (unsigned bytes, 0-255)
+  if (!(result instanceof Uint8Array)) {
+    const err = new Error("invalid entropy");
+    err.code = "invalid_entropy";
+    throw err;
+  }
+
+  const alphabet = ROOM_CODE_ALPHABET;
+  const len = alphabet.length; // 32
+  let code = "";
+  for (let i = 0; i < 6; i++) {
+    code += alphabet[result[i] % len];
+  }
+  return code;
+}
+
+function normalizePlayerName(name) {
+  if (typeof name !== "string") {
+    const err = new Error("invalid name");
+    err.code = "invalid_name";
+    throw err;
+  }
+
+  // Trim outer ASCII whitespace: space, tab, CR, LF, FF, VT
+  const trimmed = name.replace(/^[\t \r\n\f\v]+|[\t \r\n\f\v]+$/g, "");
+
+  // Collapse internal runs of ASCII whitespace to single space
+  const collapsed = trimmed.replace(/[\t \r\n\f\v]+/g, " ");
+
+  // Check allowed characters: ASCII letters, digits, space, underscore, hyphen
+  if (!/^[\p{L}\p{N} _-]+$/u.test(collapsed)) {
+    const err = new Error("invalid name");
+    err.code = "invalid_name";
+    throw err;
+  }
+
+  // Require 1..16 characters after normalization
+  if (collapsed.length < 1 || collapsed.length > 16) {
+    const err = new Error("invalid name");
+    err.code = "invalid_name";
+    throw err;
+  }
+
+  return collapsed;
+}
+
+export { ROOM_CODE_ALPHABET, generateRoomCode, normalizePlayerName };

--- a/room-protocol.js
+++ b/room-protocol.js
@@ -1,7 +1,7 @@
 const ROOM_PROTOCOL_VERSION = 1;
 
 function createRoomProtocol({ registry, send }) {
-  if (typeof registry !== "object" || typeof send !== "function") {
+  if (typeof registry !== "object" || registry === null || typeof send !== "function" || typeof registry.createRoom !== "function" || typeof registry.joinRoom !== "function" || typeof registry.setPlayerReady !== "function") {
     const err = new Error("invalid_configuration");
     err.code = "invalid_configuration";
     throw err;
@@ -33,7 +33,7 @@ function createRoomProtocol({ registry, send }) {
 
   // Validate requestId: if present in message (not undefined), must be a bounded ASCII token
   function validateRequestId(requestId) {
-    if (requestId === undefined) return true;
+    if (requestId === undefined) return false;
     if (typeof requestId !== "string") return false;
     if (requestId.length === 0 || requestId.length > 64) return false;
     for (let i = 0; i < requestId.length; i++) {
@@ -100,16 +100,22 @@ function createRoomProtocol({ registry, send }) {
           sendError(connectionId, "already_in_room", null, requestId);
           return;
         }
-        const result = registry.createRoom({ name: msg.name });
-        sessions.set(connectionId, { playerId: result.playerId, room: result.room });
-        send(connectionId, {
-          type: "room_state",
-          protocolVersion: ROOM_PROTOCOL_VERSION,
-          requestId: requestId,
-          room: deepClone(result.room),
-          self: { playerId: result.playerId },
-          invitePath: `/?room=${result.room.code}`,
-        });
+        try {
+          const result = registry.createRoom({ name: msg.name });
+          sessions.set(connectionId, { playerId: result.playerId, room: result.room });
+          send(connectionId, {
+            type: "room_state",
+            protocolVersion: ROOM_PROTOCOL_VERSION,
+            requestId: requestId,
+            room: deepClone(result.room),
+            self: { playerId: result.playerId },
+            invitePath: `/?room=${result.room.code}`,
+          });
+        } catch (e) {
+          const extra = Number.isSafeInteger(e.currentSeq) ? { currentSeq: e.currentSeq } : null;
+          sendError(connectionId, e.code, extra, requestId);
+          return;
+        }
         break;
       }
 
@@ -127,10 +133,16 @@ function createRoomProtocol({ registry, send }) {
           sendError(connectionId, "invalid_request", null, requestId);
           return;
         }
-        const result = registry.joinRoom({ code: msg.code, name: msg.name });
-        sessions.set(connectionId, { playerId: result.playerId, room: result.room });
-        // Broadcast to all players in the room (including the joiner)
-        broadcastRoomState(result.room, connectionId, requestId);
+        try {
+          const result = registry.joinRoom({ code: msg.code, name: msg.name });
+          sessions.set(connectionId, { playerId: result.playerId, room: result.room });
+          // Broadcast to all players in the room (including the joiner)
+          broadcastRoomState(result.room, connectionId, requestId);
+        } catch (e) {
+          const extra = Number.isSafeInteger(e.currentSeq) ? { currentSeq: e.currentSeq } : null;
+          sendError(connectionId, e.code, extra, requestId);
+          return;
+        }
         break;
       }
 

--- a/room-protocol.js
+++ b/room-protocol.js
@@ -1,0 +1,206 @@
+const ROOM_PROTOCOL_VERSION = 1;
+
+function createRoomProtocol({ registry, send }) {
+  if (typeof registry !== "object" || typeof send !== "function") {
+    const err = new Error("invalid_configuration");
+    err.code = "invalid_configuration";
+    throw err;
+  }
+
+  const sessions = new Map(); // connectionId -> { playerId, room }
+
+  function connect(connectionId) {
+    if (typeof connectionId !== "string" || connectionId.trim().length === 0) {
+      const err = new Error("invalid_connection_id");
+      err.code = "invalid_connection_id";
+      throw err;
+    }
+    if (sessions.has(connectionId)) {
+      const err = new Error("connection_exists");
+      err.code = "connection_exists";
+      throw err;
+    }
+    sessions.set(connectionId, null);
+    send(connectionId, { type: "connected", protocolVersion: ROOM_PROTOCOL_VERSION });
+  }
+
+  function disconnect(connectionId) {
+    if (!sessions.has(connectionId)) {
+      return;
+    }
+    sessions.delete(connectionId);
+  }
+
+  // Validate requestId: if present in message (not undefined), must be a bounded ASCII token
+  function validateRequestId(requestId) {
+    if (requestId === undefined) return true;
+    if (typeof requestId !== "string") return false;
+    if (requestId.length === 0 || requestId.length > 64) return false;
+    for (let i = 0; i < requestId.length; i++) {
+      const ch = requestId.charCodeAt(i);
+      // Only allow alphanumeric, underscore, hyphen
+      if (!((ch >= 48 && ch <= 57) || (ch >= 65 && ch <= 90) || (ch >= 97 && ch <= 122) || ch === 95 || ch === 45)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function sendError(connectionId, code, extra, requestId) {
+    const msg = { type: "error", protocolVersion: ROOM_PROTOCOL_VERSION, code };
+    if (extra) Object.assign(msg, extra);
+    // requestId is only included when it's a valid string
+    if (typeof requestId === "string" && requestId.length > 0) {
+      msg.requestId = requestId;
+    } else {
+      msg.requestId = null;
+    }
+    send(connectionId, msg);
+  }
+
+  function receive(connectionId, rawMessage) {
+    if (!sessions.has(connectionId)) {
+      const err = new Error("connection_not_found");
+      err.code = "connection_not_found";
+      throw err;
+    }
+
+    let msg;
+    try {
+      msg = JSON.parse(rawMessage);
+    } catch (e) {
+      sendError(connectionId, "invalid_json", null, undefined);
+      return;
+    }
+
+    if (typeof msg !== "object" || msg === null || Array.isArray(msg) || typeof msg.type !== "string") {
+      sendError(connectionId, "invalid_message", null, undefined);
+      return;
+    }
+
+    // Validate requestId early - if invalid, reject before processing the command
+    const requestId = msg.requestId;
+    if (!validateRequestId(requestId)) {
+      sendError(connectionId, "invalid_request_id", null, undefined);
+      return;
+    }
+
+    const session = sessions.get(connectionId);
+    const selfPlayerId = session ? session.playerId : null;
+    const selfRoomCode = session && session.room ? session.room.code : null;
+
+    switch (msg.type) {
+      case "create_room": {
+        if (!msg.name || typeof msg.name !== "string") {
+          sendError(connectionId, "invalid_request", null, requestId);
+          return;
+        }
+        // Check already_in_room before creating
+        if (session && session.room) {
+          sendError(connectionId, "already_in_room", null, requestId);
+          return;
+        }
+        const result = registry.createRoom({ name: msg.name });
+        sessions.set(connectionId, { playerId: result.playerId, room: result.room });
+        send(connectionId, {
+          type: "room_state",
+          protocolVersion: ROOM_PROTOCOL_VERSION,
+          requestId: requestId,
+          room: deepClone(result.room),
+          self: { playerId: result.playerId },
+          invitePath: `/?room=${result.room.code}`,
+        });
+        break;
+      }
+
+      case "join_room": {
+        // Check already_in_room first
+        if (session && session.room) {
+          sendError(connectionId, "already_in_room", null, requestId);
+          return;
+        }
+        if (!msg.code || typeof msg.code !== "string") {
+          sendError(connectionId, "invalid_request", null, requestId);
+          return;
+        }
+        if (!msg.name || typeof msg.name !== "string") {
+          sendError(connectionId, "invalid_request", null, requestId);
+          return;
+        }
+        const result = registry.joinRoom({ code: msg.code, name: msg.name });
+        sessions.set(connectionId, { playerId: result.playerId, room: result.room });
+        // Broadcast to all players in the room (including the joiner)
+        broadcastRoomState(result.room, connectionId, requestId);
+        break;
+      }
+
+      case "set_ready": {
+        // Check not_in_room first
+        if (!session || !session.room) {
+          sendError(connectionId, "not_in_room", null, requestId);
+          return;
+        }
+        if (typeof msg.ready !== "boolean") {
+          sendError(connectionId, "invalid_request", null, requestId);
+          return;
+        }
+        try {
+          const result = registry.setPlayerReady({
+            code: selfRoomCode,
+            playerId: selfPlayerId,
+            ready: msg.ready,
+            expectedSeq: msg.expectedSeq,
+          });
+          sessions.set(connectionId, { playerId: selfPlayerId, room: result });
+          broadcastRoomState(result, connectionId, requestId);
+        } catch (e) {
+          if (e.code === "stale_state") {
+            sendError(connectionId, e.code, { currentSeq: e.currentSeq }, requestId);
+          } else {
+            sendError(connectionId, e.code, null, requestId);
+          }
+        }
+        break;
+      }
+
+      default: {
+        sendError(connectionId, "unsupported_message", null, requestId);
+        break;
+      }
+    }
+  }
+
+  function broadcastRoomState(room, excludeConnectionId, requestForRequestId) {
+    for (const [connId, sess] of sessions) {
+      if (!sess || !sess.room || sess.room.code !== room.code) continue;
+      if (connId === excludeConnectionId) {
+        // Sender gets the message with requestId and self
+        send(connId, {
+          type: "room_state",
+          protocolVersion: ROOM_PROTOCOL_VERSION,
+          requestId: requestForRequestId,
+          room: deepClone(room),
+          self: { playerId: sess.playerId },
+          invitePath: `/?room=${room.code}`,
+        });
+      } else {
+        // Others get it without requestId but with self
+        send(connId, {
+          type: "room_state",
+          protocolVersion: ROOM_PROTOCOL_VERSION,
+          room: deepClone(room),
+          self: { playerId: sess.playerId },
+          invitePath: `/?room=${room.code}`,
+        });
+      }
+    }
+  }
+
+  function deepClone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  return { connect, receive, disconnect };
+}
+
+export { createRoomProtocol, ROOM_PROTOCOL_VERSION };

--- a/room-protocol.js
+++ b/room-protocol.js
@@ -1,7 +1,7 @@
 const ROOM_PROTOCOL_VERSION = 1;
 
 function createRoomProtocol({ registry, send }) {
-  if (typeof registry !== "object" || registry === null || typeof send !== "function" || typeof registry.createRoom !== "function" || typeof registry.joinRoom !== "function" || typeof registry.setPlayerReady !== "function") {
+  if (typeof registry !== "object" || registry === null || typeof send !== "function" || typeof registry.createRoom !== "function" || typeof registry.joinRoom !== "function" || typeof registry.setPlayerReady !== "function" || typeof registry.updatePlayerState !== "function" || typeof registry.requestRematch !== "function") {
     const err = new Error("invalid_configuration");
     err.code = "invalid_configuration";
     throw err;
@@ -172,6 +172,88 @@ function createRoomProtocol({ registry, send }) {
             sendError(connectionId, e.code, null, requestId);
           }
         }
+        break;
+      }
+
+      case "update_player_state": {
+        // Must be in a room with an authoritative session
+        if (!session || !session.room) {
+          sendError(connectionId, "not_in_room", null, requestId);
+          return;
+        }
+        try {
+          const result = registry.updatePlayerState({
+            code: selfRoomCode,
+            playerId: selfPlayerId,
+            matchId: msg.matchId,
+            updateSeq: msg.updateSeq,
+            state: msg.state,
+          });
+          // Find the opponent session (distinct connection, same room)
+          const senderName = result.players.find((p) => p.id === selfPlayerId)?.name ?? null;
+          const acceptedState = result.players.find((p) => p.id === selfPlayerId)?.gameState ?? null;
+          const acceptedUpdateSeq = result.players.find((p) => p.id === selfPlayerId)?.currentUpdateSeq ?? msg.updateSeq;
+          // Send player_state_accepted to sender first
+          send(connectionId, {
+            type: "player_state_accepted",
+            protocolVersion: ROOM_PROTOCOL_VERSION,
+            requestId: requestId,
+            matchId: msg.matchId,
+            updateSeq: acceptedUpdateSeq,
+          });
+          // Send opponent_state projection to the other connected distinct player in the room
+          for (const [opConnId, opSess] of sessions) {
+            if (!opSess || !opSess.room || opSess.room.code !== result.code) continue;
+            if (opConnId === connectionId) continue;
+            send(opConnId, {
+              type: "opponent_state",
+              protocolVersion: ROOM_PROTOCOL_VERSION,
+              matchId: msg.matchId,
+              opponent: {
+                name: senderName,
+                updateSeq: acceptedUpdateSeq,
+                board: acceptedState.board,
+                score: acceptedState.score,
+                lines: acceptedState.lines,
+                gameOver: acceptedState.gameOver,
+              },
+            });
+          }
+          if (result.match.result) {
+            for (const [connId, sess] of sessions) {
+              if (!sess || !sess.room || sess.room.code !== result.code) continue;
+              send(connId, {
+                type: "match_result",
+                protocolVersion: ROOM_PROTOCOL_VERSION,
+                matchId: result.match.id,
+                winnerId: result.match.result.winnerId,
+                loserId: result.match.result.loserId,
+              });
+            }
+          }
+        } catch (e) {
+          const extra = e.code === "stale_player_state" && Number.isSafeInteger(e.currentUpdateSeq)
+            ? { currentUpdateSeq: e.currentUpdateSeq }
+            : null;
+          sendError(connectionId, e.code, extra, requestId);
+        }
+        break;
+      }
+
+      case "request_rematch": {
+        if (!session || !session.room) { sendError(connectionId, "not_in_room", null, requestId); return; }
+        try {
+          const result = registry.requestRematch({ code: selfRoomCode, playerId: selfPlayerId, matchId: msg.matchId });
+          const current = result.match;
+          if (current.id === msg.matchId && current.rematchAccepted) {
+            for (const [connId, sess] of sessions) {
+              if (sess?.room?.code === result.code) send(connId, { type: "rematch_status", protocolVersion: ROOM_PROTOCOL_VERSION, matchId: msg.matchId, acceptedPlayerIds: current.rematchAccepted.slice() });
+            }
+          } else {
+            for (const [connId, sess] of sessions) if (sess?.room?.code === result.code) sessions.set(connId, { playerId: sess.playerId, room: result });
+            broadcastRoomState(result, connectionId, requestId);
+          }
+        } catch (e) { sendError(connectionId, e.code, null, requestId); }
         break;
       }
 

--- a/room-registry.js
+++ b/room-registry.js
@@ -20,6 +20,7 @@ function createRoomRegistry({
   }
 
   const rooms = new Map();
+  const issuedMatchIdsByRoom = new Map();
 
   function isValidRoomCode(code) {
     if (typeof code !== "string" || code.length !== 6) return false;
@@ -74,6 +75,7 @@ function createRoomRegistry({
           players: [{ id: playerId, name: normalizedName, ready: false }],
         };
         rooms.set(code, room);
+        issuedMatchIdsByRoom.set(code, new Set());
         return {
           playerId,
           room: deepClone(room),
@@ -340,8 +342,260 @@ function createRoomRegistry({
       // 12. Attach prepared match if both players are now ready
       if (preparedMatch) {
         targetRoom.match = preparedMatch;
+        issuedMatchIdsByRoom.get(targetRoom.code).add(preparedMatch.id);
       }
 
+      return deepClone(targetRoom);
+    },
+
+    updatePlayerState({ code, playerId, matchId, updateSeq, state }) {
+      // 1. Normalize + validate room code
+      if (code === null || code === undefined || typeof code !== "string") {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+      const trimmedCode = code.trim().toUpperCase();
+      if (!isValidRoomCode(trimmedCode)) {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+
+      // 2. Look up authoritative room
+      const lowerKey = trimmedCode.toLowerCase();
+      let targetRoom = null;
+      for (const [key, room] of rooms) {
+        if (key.toLowerCase() === lowerKey) {
+          targetRoom = room;
+          break;
+        }
+      }
+      if (!targetRoom) {
+        const err = new Error("room_not_found");
+        err.code = "room_not_found";
+        throw err;
+      }
+
+      // 3. Validate match exists and started
+      if (!Object.hasOwn(targetRoom, "match")) {
+        const err = new Error("match_not_started");
+        err.code = "match_not_started";
+        throw err;
+      }
+
+      // 4. Validate matchId matches room's current match
+      if (targetRoom.match.id !== matchId) {
+        const err = new Error("match_mismatch");
+        err.code = "match_mismatch";
+        throw err;
+      }
+      if (Object.hasOwn(targetRoom.match, "result")) {
+        const err = new Error("match_finished");
+        err.code = "match_finished";
+        throw err;
+      }
+
+      // 5. Validate playerId: must be a non-empty trimmed string
+      if (typeof playerId !== "string" || !playerId.trim()) {
+        const err = new Error("invalid_player_id");
+        err.code = "invalid_player_id";
+        throw err;
+      }
+
+      // 6. Find player in room
+      let targetPlayer = null;
+      for (const player of targetRoom.players) {
+        if (player.id === playerId) {
+          targetPlayer = player;
+          break;
+        }
+      }
+      if (!targetPlayer) {
+        const err = new Error("player_not_found");
+        err.code = "player_not_found";
+        throw err;
+      }
+
+      // 7. Validate updateSeq: must be a safe integer in 1..1,000,000,000
+      if (
+        typeof updateSeq !== "number" ||
+        !Number.isInteger(updateSeq) ||
+        updateSeq < 1 ||
+        updateSeq > 1_000_000_000
+      ) {
+        const err = new Error("invalid_update_sequence");
+        err.code = "invalid_update_sequence";
+        throw err;
+      }
+
+      // 8. Check per-player sequence: expected is currentUpdateSeq + 1 (or 1 if first)
+      const expectedSeq = (targetPlayer.currentUpdateSeq ?? 0) + 1;
+      if (updateSeq !== expectedSeq) {
+        const err = new Error("stale_player_state");
+        err.code = "stale_player_state";
+        err.currentUpdateSeq = targetPlayer.currentUpdateSeq ?? 0;
+        throw err;
+      }
+
+      // 9. Validate state shape: exactly board, score, lines, gameOver — no extra keys
+      const expectedStateKeys = new Set(["board", "score", "lines", "gameOver"]);
+      if (
+        typeof state !== "object" ||
+        state === null ||
+        Array.isArray(state) ||
+        Object.keys(state).length !== 4 ||
+        [...Object.keys(state)].some((k) => !expectedStateKeys.has(k))
+      ) {
+        const err = new Error("invalid_player_state");
+        err.code = "invalid_player_state";
+        throw err;
+      }
+
+      // 10. Validate board: exactly 20 rows x 10 columns, each cell null or valid token
+      const board = state.board;
+      if (
+        !Array.isArray(board) ||
+        board.length !== 20
+      ) {
+        const err = new Error("invalid_player_state");
+        err.code = "invalid_player_state";
+        throw err;
+      }
+      const validTokens = new Set(["I", "O", "T", "S", "Z", "J", "L"]);
+      for (let r = 0; r < 20; r++) {
+        const row = board[r];
+        if (!Array.isArray(row) || row.length !== 10) {
+          const err = new Error("invalid_player_state");
+          err.code = "invalid_player_state";
+          throw err;
+        }
+        for (let c = 0; c < 10; c++) {
+          const cell = row[c];
+          if (cell !== null && !validTokens.has(cell)) {
+            const err = new Error("invalid_player_state");
+            err.code = "invalid_player_state";
+            throw err;
+          }
+        }
+      }
+
+      // 11. Validate score: non-negative safe integer ≤ 1,000,000,000
+      const score = state.score;
+      if (
+        typeof score !== "number" ||
+        !Number.isInteger(score) ||
+        score < 0 ||
+        score > 1_000_000_000
+      ) {
+        const err = new Error("invalid_player_state");
+        err.code = "invalid_player_state";
+        throw err;
+      }
+
+      // 12. Validate lines: non-negative safe integer ≤ 1,000,000,000
+      const lines = state.lines;
+      if (
+        typeof lines !== "number" ||
+        !Number.isInteger(lines) ||
+        lines < 0 ||
+        lines > 1_000_000_000
+      ) {
+        const err = new Error("invalid_player_state");
+        err.code = "invalid_player_state";
+        throw err;
+      }
+
+      // 13. Validate gameOver: must be boolean
+      if (typeof state.gameOver !== "boolean") {
+        const err = new Error("invalid_player_state");
+        err.code = "invalid_player_state";
+        throw err;
+      }
+
+      // 14. All validation passed — resolve terminal authority before any mutation.
+      const acceptedState = deepClone(state);
+      acceptedState.updateSeq = updateSeq;
+      let winner = null;
+      if (acceptedState.gameOver) {
+        winner = targetRoom.players.find((player) => player.id !== targetPlayer.id);
+        if (!winner) {
+          const err = new Error("invalid_match_state");
+          err.code = "invalid_match_state";
+          throw err;
+        }
+      }
+
+      targetPlayer.gameState = acceptedState;
+      targetPlayer.currentUpdateSeq = updateSeq;
+
+      // A validated terminal report resolves this match exactly once. The registry,
+      // not either browser, owns the winner/loser record.
+      if (winner) {
+        targetRoom.match.result = { winnerId: winner.id, loserId: targetPlayer.id };
+        targetRoom.match.rematchAccepted = [];
+      }
+
+      // 15. Return complete detached room snapshot (room seq unchanged)
+      return deepClone(targetRoom);
+    },
+
+    requestRematch({ code, playerId, matchId }) {
+      const targetRoom = rooms.get(String(code || "").trim().toUpperCase());
+      if (!targetRoom) {
+        const err = new Error("room_not_found");
+        err.code = "room_not_found";
+        throw err;
+      }
+      if (!targetRoom.match || targetRoom.match.id !== matchId) {
+        const err = new Error("match_mismatch");
+        err.code = "match_mismatch";
+        throw err;
+      }
+      if (!targetRoom.match.result) {
+        const err = new Error("match_not_finished");
+        err.code = "match_not_finished";
+        throw err;
+      }
+      const player = targetRoom.players.find((item) => item.id === playerId);
+      if (!player) {
+        const err = new Error("player_not_found");
+        err.code = "player_not_found";
+        throw err;
+      }
+      const accepted = targetRoom.match.rematchAccepted || (targetRoom.match.rematchAccepted = []);
+      if (accepted.includes(playerId)) return deepClone(targetRoom);
+      const completesRematch = accepted.length + 1 >= targetRoom.players.length;
+      if (!completesRematch) {
+        accepted.push(playerId);
+        return deepClone(targetRoom);
+      }
+
+      // Prepare and validate the next match before committing the final vote.
+      let nextMatchId;
+      let nextSeed;
+      try {
+        nextMatchId = createMatchId();
+        nextSeed = createMatchSeed();
+      } catch {
+        const err = new Error("invalid_match_state");
+        err.code = "invalid_match_state";
+        throw err;
+      }
+      const issuedMatchIds = issuedMatchIdsByRoom.get(targetRoom.code);
+      if (typeof nextMatchId !== "string" || !/^[A-Za-z0-9_-]{1,64}$/.test(nextMatchId) || !issuedMatchIds || issuedMatchIds.has(nextMatchId) || !Number.isInteger(nextSeed) || nextSeed < 0 || nextSeed > 0xffffffff) {
+        const err = new Error("invalid_match_state");
+        err.code = "invalid_match_state";
+        throw err;
+      }
+      targetRoom.seq += 1;
+      for (const item of targetRoom.players) {
+        item.ready = true;
+        delete item.gameState;
+        delete item.currentUpdateSeq;
+      }
+      targetRoom.match = { id: nextMatchId, seed: nextSeed, startedSeq: targetRoom.seq };
+      issuedMatchIds.add(nextMatchId);
       return deepClone(targetRoom);
     },
   };

--- a/room-registry.js
+++ b/room-registry.js
@@ -1,10 +1,12 @@
-import { randomUUID } from "node:crypto";
+import { randomUUID, randomBytes } from "node:crypto";
 import { generateRoomCode, normalizePlayerName, ROOM_CODE_ALPHABET } from "./room-code.js";
 
 function createRoomRegistry({
   generateCode = generateRoomCode,
   createPlayerId = randomUUID,
   maxCodeAttempts: attemptLimit = 32,
+  createMatchId = () => randomUUID(),
+  createMatchSeed = () => randomBytes(4).readUInt32BE(0),
 } = {}) {
   if (
     typeof attemptLimit !== "number" ||
@@ -265,14 +267,80 @@ function createRoomRegistry({
         throw err;
       }
 
-      // 8. Idempotent no-op: same ready value → return snapshot without seq increment
+      // 8. If match already started, reject readiness changes before any mutation or idempotent check
+      if (Object.hasOwn(targetRoom, "match")) {
+        const err = new Error("match_started");
+        err.code = "match_started";
+        throw err;
+      }
+
+      // 9. Idempotent no-op: same ready value → return snapshot without seq increment
       if (targetPlayer.ready === ready) {
         return deepClone(targetRoom);
       }
 
-      // 9. Change ready, increment seq once, return detached snapshot
+      // 10. If this transition would make both players ready, validate match authority
+      //     against the still-unmodified room before any mutation.
+      const wouldMakeBothReady =
+        ready === true &&
+        targetRoom.players.length === 2 &&
+        !targetPlayer.ready &&
+        targetRoom.players.some(
+          (p) => p.id !== targetPlayer.id && p.ready === true,
+        );
+
+      let preparedMatch = null;
+      if (wouldMakeBothReady) {
+        let matchId;
+        try {
+          matchId = createMatchId();
+        } catch (e) {
+          const err = new Error("invalid_match_id");
+          err.code = "invalid_match_id";
+          throw err;
+        }
+        if (
+          typeof matchId !== "string" ||
+          !matchId.trim() ||
+          matchId.length < 1 ||
+          matchId.length > 64 ||
+          !/^[A-Za-z0-9_-]+$/.test(matchId)
+        ) {
+          const err = new Error("invalid_match_id");
+          err.code = "invalid_match_id";
+          throw err;
+        }
+
+        let matchSeed;
+        try {
+          matchSeed = createMatchSeed();
+        } catch (e) {
+          const err = new Error("invalid_match_seed");
+          err.code = "invalid_match_seed";
+          throw err;
+        }
+        if (
+          typeof matchSeed !== "number" ||
+          !Number.isInteger(matchSeed) ||
+          matchSeed < 0 ||
+          matchSeed > 0xffffffff
+        ) {
+          const err = new Error("invalid_match_seed");
+          err.code = "invalid_match_seed";
+          throw err;
+        }
+
+        preparedMatch = { id: matchId, seed: matchSeed, startedSeq: targetRoom.seq + 1 };
+      }
+
+      // 11. Change ready, increment seq once
       targetPlayer.ready = ready;
       targetRoom.seq += 1;
+
+      // 12. Attach prepared match if both players are now ready
+      if (preparedMatch) {
+        targetRoom.match = preparedMatch;
+      }
 
       return deepClone(targetRoom);
     },

--- a/room-registry.js
+++ b/room-registry.js
@@ -4,11 +4,11 @@ import { generateRoomCode, normalizePlayerName, ROOM_CODE_ALPHABET } from "./roo
 function createRoomRegistry({
   generateCode = generateRoomCode,
   createPlayerId = randomUUID,
-  maxCodeAttempts = 32,
+  maxCodeAttempts: attemptLimit = 32,
 } = {}) {
   void generateCode;
   void createPlayerId;
-  void maxCodeAttempts;
+  void attemptLimit;
   void normalizePlayerName;
   void ROOM_CODE_ALPHABET;
   throw new Error("room registry not implemented");

--- a/room-registry.js
+++ b/room-registry.js
@@ -6,12 +6,107 @@ function createRoomRegistry({
   createPlayerId = randomUUID,
   maxCodeAttempts: attemptLimit = 32,
 } = {}) {
-  void generateCode;
-  void createPlayerId;
-  void attemptLimit;
-  void normalizePlayerName;
-  void ROOM_CODE_ALPHABET;
-  throw new Error("room registry not implemented");
+  if (
+    typeof attemptLimit !== "number" ||
+    !Number.isInteger(attemptLimit) ||
+    attemptLimit < 1 ||
+    attemptLimit > 128
+  ) {
+    const err = new Error("invalid_configuration");
+    err.code = "invalid_configuration";
+    throw err;
+  }
+
+  const rooms = new Map();
+
+  function isValidRoomCode(code) {
+    if (typeof code !== "string" || code.length !== 6) return false;
+    const upper = code.toUpperCase();
+    for (const ch of upper) {
+      if (!ROOM_CODE_ALPHABET.includes(ch)) return false;
+    }
+    return true;
+  }
+
+  function validateRoomCode(code) {
+    if (!isValidRoomCode(code)) {
+      const err = new Error("invalid_room_code");
+      err.code = "invalid_room_code";
+      throw err;
+    }
+  }
+
+  function deepClone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  return {
+    createRoom({ name }) {
+      const normalizedName = normalizePlayerName(name);
+      let lastError = null;
+      for (let i = 0; i < attemptLimit; i++) {
+        const code = generateCode();
+        if (!isValidRoomCode(code)) {
+          const err = new Error("invalid_room_code");
+          err.code = "invalid_room_code";
+          throw err;
+        }
+        if (rooms.has(code)) {
+          continue;
+        }
+        let playerId;
+        try {
+          playerId = createPlayerId();
+        } catch (e) {
+          const err = new Error("invalid_player_id");
+          err.code = "invalid_player_id";
+          throw err;
+        }
+        if (typeof playerId !== "string" || !playerId.trim()) {
+          const err = new Error("invalid_player_id");
+          err.code = "invalid_player_id";
+          throw err;
+        }
+        const room = {
+          code,
+          seq: rooms.size + 1,
+          players: [{ id: playerId, name: normalizedName, ready: false }],
+        };
+        rooms.set(code, room);
+        return {
+          playerId,
+          room: deepClone(room),
+        };
+      }
+      if (lastError) {
+        throw lastError;
+      }
+      const err = new Error("room_code_exhausted");
+      err.code = "room_code_exhausted";
+      throw err;
+    },
+
+    getRoom(code) {
+      if (code === null || code === undefined || typeof code !== "string") {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+      const trimmed = code.trim();
+      if (!isValidRoomCode(trimmed)) {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+      const lowerKey = trimmed.toLowerCase();
+      for (const [key, room] of rooms) {
+        if (key.toLowerCase() === lowerKey) {
+          return deepClone(room);
+        }
+      }
+      return null;
+    },
+  };
 }
 
 export { createRoomRegistry };

--- a/room-registry.js
+++ b/room-registry.js
@@ -105,6 +105,88 @@ function createRoomRegistry({
       }
       return null;
     },
+
+    joinRoom({ code, name }) {
+      // Normalize and validate room code
+      if (code === null || code === undefined || typeof code !== "string") {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+      const trimmedCode = code.trim().toUpperCase();
+      if (!isValidRoomCode(trimmedCode)) {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+
+      // Look up room by normalized (lowercase) key
+      const lowerKey = trimmedCode.toLowerCase();
+      let targetRoom = null;
+      for (const [key, room] of rooms) {
+        if (key.toLowerCase() === lowerKey) {
+          targetRoom = room;
+          break;
+        }
+      }
+      if (!targetRoom) {
+        const err = new Error("room_not_found");
+        err.code = "room_not_found";
+        throw err;
+      }
+
+      // Normalize name
+      const normalizedName = normalizePlayerName(name);
+
+      // Check for duplicate normalized names (case-insensitive) in the room
+      const lowerNormalizedName = normalizedName.toLowerCase();
+      for (const player of targetRoom.players) {
+        if (player.name.toLowerCase() === lowerNormalizedName) {
+          const err = new Error("name_taken");
+          err.code = "name_taken";
+          throw err;
+        }
+      }
+
+      // Enforce two-player cap before ID allocation
+      if (targetRoom.players.length >= 2) {
+        const err = new Error("room_full");
+        err.code = "room_full";
+        throw err;
+      }
+
+      // Allocate player ID
+      let playerId;
+      try {
+        playerId = createPlayerId();
+      } catch (e) {
+        const err = new Error("invalid_player_id");
+        err.code = "invalid_player_id";
+        throw err;
+      }
+      if (typeof playerId !== "string" || !playerId.trim()) {
+        const err = new Error("invalid_player_id");
+        err.code = "invalid_player_id";
+        throw err;
+      }
+      // Ensure unique within room
+      for (const player of targetRoom.players) {
+        if (player.id === playerId) {
+          const err = new Error("invalid_player_id");
+          err.code = "invalid_player_id";
+          throw err;
+        }
+      }
+
+      // Append ready:false player and increment seq
+      targetRoom.seq += 1;
+      targetRoom.players.push({ id: playerId, name: normalizedName, ready: false });
+
+      return {
+        playerId,
+        room: deepClone(targetRoom),
+      };
+    },
   };
 }
 

--- a/room-registry.js
+++ b/room-registry.js
@@ -1,0 +1,17 @@
+import { randomUUID } from "node:crypto";
+import { generateRoomCode, normalizePlayerName, ROOM_CODE_ALPHABET } from "./room-code.js";
+
+function createRoomRegistry({
+  generateCode = generateRoomCode,
+  createPlayerId = randomUUID,
+  maxCodeAttempts = 32,
+} = {}) {
+  void generateCode;
+  void createPlayerId;
+  void maxCodeAttempts;
+  void normalizePlayerName;
+  void ROOM_CODE_ALPHABET;
+  throw new Error("room registry not implemented");
+}
+
+export { createRoomRegistry };

--- a/room-registry.js
+++ b/room-registry.js
@@ -21,8 +21,7 @@ function createRoomRegistry({
 
   function isValidRoomCode(code) {
     if (typeof code !== "string" || code.length !== 6) return false;
-    const upper = code.toUpperCase();
-    for (const ch of upper) {
+    for (const ch of code) {
       if (!ROOM_CODE_ALPHABET.includes(ch)) return false;
     }
     return true;
@@ -69,7 +68,7 @@ function createRoomRegistry({
         }
         const room = {
           code,
-          seq: rooms.size + 1,
+          seq: 1,
           players: [{ id: playerId, name: normalizedName, ready: false }],
         };
         rooms.set(code, room);
@@ -92,7 +91,7 @@ function createRoomRegistry({
         err.code = "invalid_room_code";
         throw err;
       }
-      const trimmed = code.trim();
+      const trimmed = code.trim().toUpperCase();
       if (!isValidRoomCode(trimmed)) {
         const err = new Error("invalid_room_code");
         err.code = "invalid_room_code";

--- a/room-registry.js
+++ b/room-registry.js
@@ -187,6 +187,95 @@ function createRoomRegistry({
         room: deepClone(targetRoom),
       };
     },
+
+    setPlayerReady({ code, playerId, ready, expectedSeq }) {
+      // 1. Normalize + validate room code
+      if (code === null || code === undefined || typeof code !== "string") {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+      const trimmedCode = code.trim().toUpperCase();
+      if (!isValidRoomCode(trimmedCode)) {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+
+      // 2. Look up room
+      const lowerKey = trimmedCode.toLowerCase();
+      let targetRoom = null;
+      for (const [key, room] of rooms) {
+        if (key.toLowerCase() === lowerKey) {
+          targetRoom = room;
+          break;
+        }
+      }
+      if (!targetRoom) {
+        const err = new Error("room_not_found");
+        err.code = "room_not_found";
+        throw err;
+      }
+
+      // 3. Validate ready is a boolean
+      if (typeof ready !== "boolean") {
+        const err = new Error("invalid_ready");
+        err.code = "invalid_ready";
+        throw err;
+      }
+
+      // 4. Validate expectedSeq is a safe integer >= 1
+      if (
+        typeof expectedSeq !== "number" ||
+        !Number.isInteger(expectedSeq) ||
+        expectedSeq < 1 ||
+        expectedSeq > Number.MAX_SAFE_INTEGER
+      ) {
+        const err = new Error("invalid_sequence");
+        err.code = "invalid_sequence";
+        throw err;
+      }
+
+      // 5. Compare expectedSeq to room.seq — stale_state if mismatch
+      if (expectedSeq !== targetRoom.seq) {
+        const err = new Error("stale_state");
+        err.code = "stale_state";
+        err.currentSeq = targetRoom.seq;
+        throw err;
+      }
+
+      // 6. Validate playerId: must be a non-empty trimmed string
+      if (typeof playerId !== "string" || !playerId.trim()) {
+        const err = new Error("invalid_player_id");
+        err.code = "invalid_player_id";
+        throw err;
+      }
+
+      // 7. Find player in room — player_not_found if absent
+      let targetPlayer = null;
+      for (const player of targetRoom.players) {
+        if (player.id === playerId) {
+          targetPlayer = player;
+          break;
+        }
+      }
+      if (!targetPlayer) {
+        const err = new Error("player_not_found");
+        err.code = "player_not_found";
+        throw err;
+      }
+
+      // 8. Idempotent no-op: same ready value → return snapshot without seq increment
+      if (targetPlayer.ready === ready) {
+        return deepClone(targetRoom);
+      }
+
+      // 9. Change ready, increment seq once, return detached snapshot
+      targetPlayer.ready = ready;
+      targetRoom.seq += 1;
+
+      return deepClone(targetRoom);
+    },
   };
 }
 

--- a/room-websocket-server.js
+++ b/room-websocket-server.js
@@ -32,6 +32,8 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
   // Track all owned sockets and their connection IDs
   const clients = new Map(); // connectionId -> WebSocket
 
+  let closePromise = null;
+
   const upgradeListener = (request, socket, head) => {
     const url = new URL(request.url, `http://${request.headers.host}`);
     const pathname = url.pathname;
@@ -82,6 +84,11 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
       return;
     }
 
+    if (clients.has(connectionId)) {
+      ws.close(1011, "internal_error");
+      return;
+    }
+
     clients.set(connectionId, ws);
 
     // Register with protocol
@@ -126,27 +133,35 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
   // Return async idempotent close
   return {
     async close() {
-      // Remove only our owned upgrade listener
-      server.removeListener("upgrade", upgradeListener);
-
-      // Terminate all client sockets
-      for (const [connectionId, ws] of clients) {
-        try {
-          ws.terminate();
-        } catch (e) {
-          // ignore
-        }
-        protocol.disconnect(connectionId);
+      if (closePromise) {
+        return closePromise;
       }
-      clients.clear();
 
-      // Close only the WSS, never the HTTP server
-      await new Promise((resolve, reject) => {
-        wss.close((err) => {
-          if (err) reject(err);
-          else resolve();
+      closePromise = (async () => {
+        // Remove only our owned upgrade listener
+        server.removeListener("upgrade", upgradeListener);
+
+        // Terminate all client sockets
+        for (const [connectionId, ws] of clients) {
+          try {
+            ws.terminate();
+          } catch (e) {
+            // ignore
+          }
+          protocol.disconnect(connectionId);
+        }
+        clients.clear();
+
+        // Close only the WSS, never the HTTP server
+        await new Promise((resolve, reject) => {
+          wss.close((err) => {
+            if (err) reject(err);
+            else resolve();
+          });
         });
-      });
+      })();
+
+      return closePromise;
     },
   };
 }

--- a/room-websocket-server.js
+++ b/room-websocket-server.js
@@ -1,0 +1,154 @@
+import { WebSocketServer } from "ws";
+import { createRoomProtocol } from "./room-protocol.js";
+
+function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayloadBytes = 4096, createConnectionId }) {
+  if (typeof server !== "object" || server === null || typeof server.on !== "function") {
+    throw new Error("invalid_configuration");
+  }
+  if (typeof registry !== "object" || registry === null) {
+    throw new Error("invalid_configuration");
+  }
+  if (typeof allowedOrigin !== "string") {
+    throw new Error("invalid_configuration");
+  }
+  if (typeof maxPayloadBytes !== "number" || !Number.isInteger(maxPayloadBytes) || maxPayloadBytes < 1) {
+    throw new Error("invalid_configuration");
+  }
+  if (typeof createConnectionId !== "function") {
+    throw new Error("invalid_configuration");
+  }
+
+  // Create protocol EXACTLY ONCE per server creation, outside all callbacks
+  const protocol = createRoomProtocol({
+    registry,
+    send(connectionId, message) {
+      const ws = clients.get(connectionId);
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(message));
+      }
+    },
+  });
+
+  // Track all owned sockets and their connection IDs
+  const clients = new Map(); // connectionId -> WebSocket
+
+  const upgradeListener = (request, socket, head) => {
+    const url = new URL(request.url, `http://${request.headers.host}`);
+    const pathname = url.pathname;
+
+    // Exact /ws path only
+    if (pathname !== "/ws") {
+      socket.end(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\nConnection: close\r\n\r\nNot found"
+      );
+      return;
+    }
+
+    // Origin validation
+    const origin = request.headers.origin;
+    if (origin !== allowedOrigin) {
+      socket.end(
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 9\r\nConnection: close\r\n\r\nForbidden"
+      );
+      return;
+    }
+
+    // Accept the upgrade — let WSS handle it
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit("connection", ws, request);
+    });
+  };
+
+  const wss = new WebSocketServer({
+    noServer: true,
+    perMessageDeflate: false,
+    maxPayload: maxPayloadBytes,
+  });
+
+  server.on("upgrade", upgradeListener);
+
+  wss.on("connection", (ws) => {
+    // Generate unique connection ID
+    let connectionId;
+    try {
+      connectionId = createConnectionId();
+    } catch (e) {
+      ws.close(1011, "internal_error");
+      return;
+    }
+
+    if (typeof connectionId !== "string" || connectionId.trim().length === 0) {
+      ws.close(1011, "internal_error");
+      return;
+    }
+
+    clients.set(connectionId, ws);
+
+    // Register with protocol
+    try {
+      protocol.connect(connectionId);
+    } catch (e) {
+      clients.delete(connectionId);
+      ws.close(1011, "internal_error");
+      return;
+    }
+
+    // Handle text messages -> protocol.receive
+    ws.on("message", (data, isBinary) => {
+      if (isBinary) {
+        ws.close(1003, "unsupported_data");
+        return;
+      }
+      try {
+        protocol.receive(connectionId, data.toString("utf8"));
+      } catch (e) {
+        // Protocol may throw on invalid messages; handle gracefully
+      }
+    });
+
+    // Handle binary close (1009 = message too big from ws maxPayload)
+    ws.on("close", (code) => {
+      // Idempotent cleanup: remove socket and disconnect from protocol
+      if (clients.has(connectionId)) {
+        clients.delete(connectionId);
+        protocol.disconnect(connectionId);
+      }
+    });
+
+    ws.on("error", () => {
+      if (clients.has(connectionId)) {
+        clients.delete(connectionId);
+        protocol.disconnect(connectionId);
+      }
+    });
+  });
+
+  // Return async idempotent close
+  return {
+    async close() {
+      // Remove only our owned upgrade listener
+      server.removeListener("upgrade", upgradeListener);
+
+      // Terminate all client sockets
+      for (const [connectionId, ws] of clients) {
+        try {
+          ws.terminate();
+        } catch (e) {
+          // ignore
+        }
+        protocol.disconnect(connectionId);
+      }
+      clients.clear();
+
+      // Close only the WSS, never the HTTP server
+      await new Promise((resolve, reject) => {
+        wss.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+export { createRoomWebSocketServer };

--- a/room-websocket-server.js
+++ b/room-websocket-server.js
@@ -35,8 +35,17 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
   let closePromise = null;
 
   const upgradeListener = (request, socket, head) => {
-    const url = new URL(request.url, `http://${request.headers.host}`);
-    const pathname = url.pathname;
+    let pathname;
+    try {
+      if (typeof request.headers.host !== "string") throw new TypeError("invalid_host");
+      new URL(`http://${request.headers.host}`);
+      pathname = new URL(request.url, "http://stacklogic.invalid").pathname;
+    } catch {
+      socket.end(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\nConnection: close\r\n\r\nBad Request"
+      );
+      return;
+    }
 
     // Exact /ws path only
     if (pathname !== "/ws") {

--- a/server-lifecycle.js
+++ b/server-lifecycle.js
@@ -1,0 +1,44 @@
+export function closeHttpServer(server, {
+  forceAfterMs = 1000,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+} = {}) {
+  return new Promise((resolve, reject) => {
+    let timer = null;
+    let settled = false;
+    const finish = (error) => {
+      settled = true;
+      if (timer !== null) clearTimeoutFn(timer);
+      error ? reject(error) : resolve();
+    };
+    server.close(finish);
+    if (settled) return;
+    if (typeof server.closeIdleConnections === 'function') server.closeIdleConnections();
+    if (settled) return;
+    timer = setTimeoutFn(() => {
+      if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+    }, forceAfterMs);
+  });
+}
+
+export async function closeServers({ closeWebSocket, closeHttp }) {
+  const invoke = (callback) => Promise.resolve().then(callback);
+  const results = await Promise.allSettled([invoke(closeWebSocket), invoke(closeHttp)]);
+  const failures = results.filter((result) => result.status === 'rejected').map((result) => result.reason);
+  if (failures.length === 1) throw failures[0];
+  if (failures.length > 1) throw new AggregateError(failures, 'shutdown_failed');
+}
+
+export async function settleShutdown({
+  shutdown,
+  processObject = process,
+  reportError = console.error,
+}) {
+  try {
+    await shutdown();
+    processObject.exitCode = 0;
+  } catch (error) {
+    reportError('shutdown_failed', error);
+    processObject.exitCode = 1;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,11 +1,25 @@
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
 import express from 'express';
 import os from 'os';
 import fs from 'fs/promises';
 import path from 'path';
+import { createRoomRegistry } from './room-registry.js';
+import { createRoomWebSocketServer } from './room-websocket-server.js';
+import { closeHttpServer, closeServers, settleShutdown } from './server-lifecycle.js';
+
+const HOST = process.env.HOST || '0.0.0.0';
+const PORT_RAW = process.env.PORT;
+const PORT = PORT_RAW !== undefined ? Number(PORT_RAW) : 3000;
+if (PORT_RAW !== undefined && (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535)) {
+  throw new Error('invalid_port');
+}
+const STACKLOGIC_ALLOWED_ORIGIN = process.env.STACKLOGIC_ALLOWED_ORIGIN;
+if (!STACKLOGIC_ALLOWED_ORIGIN || typeof STACKLOGIC_ALLOWED_ORIGIN !== 'string') {
+  throw new Error('missing_allowed_origin');
+}
 
 const app = express();
-const PORT = 3000;
-
 const DATA_DIR = path.resolve('data');
 const HIGHSCORES_PATH = path.join(DATA_DIR, 'highscores.json');
 
@@ -83,12 +97,41 @@ app.post('/api/highscores', async (req, res) => {
   res.json({ ok: true, saved: true, scores: merged });
 });
 
-app.listen(PORT, '0.0.0.0', () => {
+const server = http.createServer(app);
+const registry = createRoomRegistry();
+const wsServer = createRoomWebSocketServer({
+  server,
+  registry,
+  allowedOrigin: STACKLOGIC_ALLOWED_ORIGIN,
+  maxPayloadBytes: 4096,
+  createConnectionId: randomUUID,
+});
+
+let shutdownPromise = null;
+
+async function shutdown() {
+  if (shutdownPromise) return shutdownPromise;
+  shutdownPromise = closeServers({
+    closeWebSocket: () => wsServer.close(),
+    closeHttp: () => closeHttpServer(server),
+  });
+  return shutdownPromise;
+}
+
+process.on('SIGTERM', () => {
+  void settleShutdown({ shutdown });
+});
+
+process.on('SIGINT', () => {
+  void settleShutdown({ shutdown });
+});
+
+server.listen(PORT, HOST, () => {
   const ips = Object.values(os.networkInterfaces())
     .flat()
     .filter((x) => x && x.family === 'IPv4' && !x.internal)
     .map((x) => x.address);
   const ip = ips[0] || '127.0.0.1';
-  console.log(`Server running on http://0.0.0.0:${PORT}`);
+  console.log(`Server running on http://${HOST}:${PORT}`);
   console.log(`LAN URL: http://${ip}:${PORT}`);
 });

--- a/tests/multiplayer-lobby-ui.test.mjs
+++ b/tests/multiplayer-lobby-ui.test.mjs
@@ -36,6 +36,7 @@ function runRoomClient(client, { search = '', modernClipboard = true } = {}) {
   let legacyCopyThrows = false;
   let selectedCopyNode = null;
   const fallbackNodes = new Set();
+  const windowListeners = new Map();
   let socket;
 
   const getElement = (id) => {
@@ -72,8 +73,20 @@ function runRoomClient(client, { search = '', modernClipboard = true } = {}) {
     href: `${origin}/play${search}`,
     search,
   };
+  const windowObject = {
+    location,
+    addEventListener(type, listener) {
+      const current = windowListeners.get(type) || [];
+      current.push(listener);
+      windowListeners.set(type, current);
+    },
+    dispatchEvent(event) {
+      for (const listener of windowListeners.get(event.type) || []) listener(event);
+      return true;
+    },
+  };
   const sandbox = {
-    window: { location },
+    window: windowObject,
     document: {
       body: {
         appendChild(node) {
@@ -152,7 +165,7 @@ describe('multiplayer lobby UI contract', () => {
     assert.match(html, /id="roomStatus"/);
     assert.match(html, /id="roomPlayers"/);
     assert.match(html, /id="roomReadyBtn"/);
-    assert.match(html, /<script type="module" src="room-client\.js\?v=0\.3\.0-beta\.1&rev=room-lobby-1"><\/script>/);
+    assert.match(html, /<script type="module" src="room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1"><\/script>/);
 
     assert.match(client, /new WebSocket\(/);
     assert.match(client, /create_room/);

--- a/tests/multiplayer-lobby-ui.test.mjs
+++ b/tests/multiplayer-lobby-ui.test.mjs
@@ -1,0 +1,324 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const root = new URL('..', import.meta.url);
+const read = (relative) => fs.readFile(new URL(relative, root), 'utf8');
+
+function createElement(id = '') {
+  const listeners = new Map();
+  return {
+    id,
+    value: '',
+    textContent: '',
+    disabled: id === 'copyCodeBtn' || id === 'copyInviteLinkBtn',
+    children: [],
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || [];
+      current.push(listener);
+      listeners.set(type, current);
+    },
+    appendChild(child) { this.children.push(child); },
+    async dispatch(type, event = {}) {
+      for (const listener of listeners.get(type) || []) await listener(event);
+    },
+  };
+}
+
+function runRoomClient(client, { search = '', modernClipboard = true } = {}) {
+  const elements = new Map();
+  const messages = [];
+  const copied = [];
+  let clipboardFailure = false;
+  let legacyCopySuccess = true;
+  let legacyCopyThrows = false;
+  let selectedCopyNode = null;
+  const fallbackNodes = new Set();
+  let socket;
+
+  const getElement = (id) => {
+    if (!elements.has(id)) elements.set(id, createElement(id));
+    return elements.get(id);
+  };
+
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.listeners = new Map();
+      this.readyState = FakeWebSocket.OPEN;
+      socket = this;
+    }
+    addEventListener(type, listener) {
+      const current = this.listeners.get(type) || [];
+      current.push(listener);
+      this.listeners.set(type, current);
+    }
+    send(payload) { messages.push(JSON.parse(payload)); }
+    async emit(type, event = {}) {
+      for (const listener of this.listeners.get(type) || []) await listener(event);
+    }
+  }
+  FakeWebSocket.OPEN = 1;
+
+  const protocol = modernClipboard ? 'https:' : 'http:';
+  const origin = `${protocol}//game.example`;
+  const location = {
+    protocol,
+    host: 'game.example',
+    origin,
+    pathname: '/play',
+    href: `${origin}/play${search}`,
+    search,
+  };
+  const sandbox = {
+    window: { location },
+    document: {
+      body: {
+        appendChild(node) {
+          fallbackNodes.add(node);
+          node.parentNode = this;
+        },
+        removeChild(node) {
+          fallbackNodes.delete(node);
+          node.parentNode = null;
+          if (selectedCopyNode === node) selectedCopyNode = null;
+        },
+      },
+      execCommand(command) {
+        if (legacyCopyThrows) throw new Error('legacy copy failed');
+        if (command !== 'copy' || !legacyCopySuccess || !selectedCopyNode) return false;
+        copied.push(selectedCopyNode.value);
+        return true;
+      },
+      getElementById: getElement,
+      createElement: () => {
+        const element = createElement();
+        element.style = {};
+        element.setAttribute = () => {};
+        element.select = () => { selectedCopyNode = element; };
+        element.remove = () => {
+          if (selectedCopyNode === element) selectedCopyNode = null;
+        };
+        return element;
+      },
+    },
+    navigator: modernClipboard ? {
+      clipboard: {
+        async writeText(text) {
+          if (clipboardFailure) throw new Error('clipboard unavailable');
+          copied.push(text);
+        },
+      },
+    } : {},
+    crypto: { randomUUID: () => 'request-id' },
+    WebSocket: FakeWebSocket,
+    URL,
+    URLSearchParams,
+    Uint8Array,
+    console,
+  };
+
+  vm.runInNewContext(client, sandbox, { filename: 'room-client.js' });
+  return {
+    copied,
+    elements,
+    getElement,
+    getFallbackNodeCount() { return fallbackNodes.size; },
+    messages,
+    setClipboardFailure(value) { clipboardFailure = value; },
+    setLegacyCopySuccess(value) { legacyCopySuccess = value; },
+    setLegacyCopyThrows(value) { legacyCopyThrows = value; },
+    socket,
+  };
+}
+
+describe('multiplayer lobby UI contract', () => {
+  it('ships an enabled create/join lobby and a browser room client', async () => {
+    const [html, client] = await Promise.all([
+      read('public/index.html'),
+      read('public/room-client.js'),
+    ]);
+
+    assert.match(html, /id="multiplayerLobby"/);
+    assert.match(html, /id="createMatchBtn"[^>]*type="button"/);
+    assert.match(html, /id="joinMatchBtn"[^>]*type="button"/);
+    assert.doesNotMatch(html, /id="createMatchBtn"[^>]*\bdisabled\b/);
+    assert.doesNotMatch(html, /id="joinMatchBtn"[^>]*\bdisabled\b/);
+    assert.doesNotMatch(html, /Coming Soon/);
+    assert.match(html, /id="roomName"/);
+    assert.match(html, /id="roomCode"/);
+    assert.match(html, /id="roomStatus"/);
+    assert.match(html, /id="roomPlayers"/);
+    assert.match(html, /id="roomReadyBtn"/);
+    assert.match(html, /<script type="module" src="room-client\.js\?v=0\.3\.0-beta\.1&rev=room-lobby-1"><\/script>/);
+
+    assert.match(client, /new WebSocket\(/);
+    assert.match(client, /create_room/);
+    assert.match(client, /join_room/);
+    assert.match(client, /set_ready/);
+    assert.match(client, /room_state/);
+    assert.match(client, /els\.roomCode\.value\s*=\s*prefilledRoom/);
+    assert.doesNotMatch(client, /prefilledRoom\s*&&\s*els\.roomName/);
+    assert.match(client, /p\.ready\s*\?\s*['"]Ready['"]\s*:\s*['"]Not ready['"]/);
+    assert.match(client, /players\?\.find\(p => p\.id === selfPlayerId\)/);
+    assert.doesNotMatch(client, /p\.playerId === selfPlayerId/);
+    assert.match(client, /updateReadyBtn\(\);\s*$/m);
+    assert.match(client, /crypto\.randomUUID\(\)/);
+    assert.doesNotMatch(client, /Math\.random/);
+  });
+
+  it('normalizes join input, pasted invite URLs, and direct room prefills', async () => {
+    const client = await read('public/room-client.js');
+    const app = runRoomClient(client);
+    app.getElement('roomName').value = 'Alex';
+    app.getElement('roomCode').value = 'a b-c d-2 3';
+
+    await app.getElement('joinMatchBtn').dispatch('click');
+    assert.deepEqual(app.messages.at(-1), {
+      type: 'join_room',
+      requestId: 'request-id',
+      code: 'ABCD23',
+      name: 'Alex',
+    });
+
+    let prevented = false;
+    await app.getElement('roomCode').dispatch('paste', {
+      clipboardData: { getData: () => 'https://game.example/play?room=a-b%20c-d23&name=secret' },
+      preventDefault() { prevented = true; },
+    });
+    assert.equal(prevented, true);
+    assert.equal(app.getElement('roomCode').value, 'ABCD23');
+
+    const prefilled = runRoomClient(client, { search: '?room=a-b%20c-d23' });
+    assert.equal(prefilled.getElement('roomCode').value, 'ABCD23');
+  });
+
+  it('exposes safe accessible copy controls only after room state', async () => {
+    const [html, client] = await Promise.all([
+      read('public/index.html'),
+      read('public/room-client.js'),
+    ]);
+    const copyCodeTag = html.match(/<button\b[^>]*\bid="copyCodeBtn"[^>]*>\s*Copy Code\s*<\/button>/)?.[0];
+    const copyInviteTag = html.match(/<button\b[^>]*\bid="copyInviteLinkBtn"[^>]*>\s*Copy Invite Link\s*<\/button>/)?.[0];
+    assert.ok(copyCodeTag, 'Copy Code button must have an accessible text label');
+    assert.ok(copyInviteTag, 'Copy Invite Link button must have an accessible text label');
+    assert.match(copyCodeTag, /\btype="button"/);
+    assert.match(copyInviteTag, /\btype="button"/);
+    assert.match(copyCodeTag, /\bdisabled\b/);
+    assert.match(copyInviteTag, /\bdisabled\b/);
+    assert.doesNotMatch(client, /\b(?:alert|prompt)\s*\(/);
+
+    const app = runRoomClient(client);
+    assert.equal(app.getElement('copyCodeBtn').disabled, true);
+    assert.equal(app.getElement('copyInviteLinkBtn').disabled, true);
+
+    await app.socket.emit('message', {
+      data: JSON.stringify({
+        type: 'room_state',
+        requestId: 'server-secret',
+        token: 'never-copy-me',
+        room: {
+          code: 'ab-cd 23',
+          seq: 1,
+          players: [{ id: 'player-1', name: 'Alex', ready: false }],
+        },
+        self: { playerId: 'player-1' },
+      }),
+    });
+    assert.equal(app.getElement('copyCodeBtn').disabled, false);
+    assert.equal(app.getElement('copyInviteLinkBtn').disabled, false);
+
+    // Copy controls must remain bound to the active room, not editable join input.
+    app.getElement('roomCode').value = 'zz-zz 99';
+
+    await app.getElement('copyCodeBtn').dispatch('click');
+    assert.equal(app.copied.at(-1), 'ABCD23');
+    assert.match(app.getElement('roomStatus').textContent, /cop/i);
+
+    await app.getElement('copyInviteLinkBtn').dispatch('click');
+    const invite = new URL(app.copied.at(-1));
+    assert.equal(invite.origin, 'https://game.example');
+    assert.equal(invite.pathname, '/play');
+    assert.deepEqual([...invite.searchParams.keys()], ['room']);
+    assert.equal(invite.searchParams.get('room'), 'ABCD23');
+    assert.doesNotMatch(invite.href, /Alex|player-1|request-id|server-secret|never-copy-me/);
+
+    app.setClipboardFailure(true);
+    await app.getElement('copyCodeBtn').dispatch('click');
+    assert.match(app.getElement('roomStatus').textContent, /fail|unable/i);
+  });
+
+  it('copies active-room values through the insecure-origin fallback', async () => {
+    const client = await read('public/room-client.js');
+    const app = runRoomClient(client, { modernClipboard: false });
+    await app.socket.emit('message', {
+      data: JSON.stringify({
+        type: 'room_state',
+        room: {
+          code: 'ab-cd 23',
+          seq: 1,
+          players: [{ id: 'player-1', name: 'Alex', ready: false }],
+        },
+        self: { playerId: 'player-1' },
+      }),
+    });
+    app.getElement('roomCode').value = 'zz-zz 99';
+
+    await app.getElement('copyCodeBtn').dispatch('click');
+    assert.equal(app.copied.at(-1), 'ABCD23');
+    assert.match(app.getElement('roomStatus').textContent, /cop/i);
+    assert.equal(app.getFallbackNodeCount(), 0);
+
+    await app.getElement('copyInviteLinkBtn').dispatch('click');
+    const invite = new URL(app.copied.at(-1));
+    assert.equal(invite.href, 'http://game.example/play?room=ABCD23');
+    assert.match(app.getElement('roomStatus').textContent, /cop/i);
+    assert.equal(app.getFallbackNodeCount(), 0);
+  });
+
+  it('reports failure when insecure-origin copying is rejected', async () => {
+    const client = await read('public/room-client.js');
+    const app = runRoomClient(client, { modernClipboard: false });
+    await app.socket.emit('message', {
+      data: JSON.stringify({
+        type: 'room_state',
+        room: {
+          code: 'ABCD23',
+          seq: 1,
+          players: [{ id: 'player-1', name: 'Alex', ready: false }],
+        },
+        self: { playerId: 'player-1' },
+      }),
+    });
+    app.setLegacyCopySuccess(false);
+
+    await app.getElement('copyCodeBtn').dispatch('click');
+    assert.equal(app.copied.length, 0);
+    assert.match(app.getElement('roomStatus').textContent, /fail|unable/i);
+    assert.equal(app.getFallbackNodeCount(), 0);
+  });
+
+  it('cleans up and reports failure when insecure-origin copying throws', async () => {
+    const client = await read('public/room-client.js');
+    const app = runRoomClient(client, { modernClipboard: false });
+    await app.socket.emit('message', {
+      data: JSON.stringify({
+        type: 'room_state',
+        room: {
+          code: 'ABCD23',
+          seq: 1,
+          players: [{ id: 'player-1', name: 'Alex', ready: false }],
+        },
+        self: { playerId: 'player-1' },
+      }),
+    });
+    app.setLegacyCopyThrows(true);
+
+    await app.getElement('copyCodeBtn').dispatch('click');
+    assert.equal(app.copied.length, 0);
+    assert.match(app.getElement('roomStatus').textContent, /fail|unable/i);
+    assert.equal(app.getFallbackNodeCount(), 0);
+  });
+});

--- a/tests/multiplayer-match-start-authority-hardening.test.mjs
+++ b/tests/multiplayer-match-start-authority-hardening.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createRoomRegistry } from '../room-registry.js';
+
+const MATCH_ID = 'match-1';
+const MATCH_SEED = 0x12345678;
+
+function sequence(values) {
+  let index = 0;
+  return () => values[index++];
+}
+
+function registryHarness(overrides = {}) {
+  return createRoomRegistry({
+    generateCode: () => 'ABC234',
+    createPlayerId: sequence(['p1', 'p2']),
+    createMatchId: () => MATCH_ID,
+    createMatchSeed: () => MATCH_SEED,
+    ...overrides,
+  });
+}
+
+function prepareSecondReady(registry) {
+  registry.createRoom({ name: 'Alpha' });
+  registry.joinRoom({ code: 'ABC234', name: 'Beta' });
+  registry.setPlayerReady({
+    code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2,
+  });
+}
+
+function startMatch(registry) {
+  prepareSecondReady(registry);
+  return registry.setPlayerReady({
+    code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3,
+  });
+}
+
+describe('Pass 02 authoritative match hardening', () => {
+  it('rejects invalid bounded ASCII match IDs before seed allocation or mutation', () => {
+    const invalidFactories = [
+      () => '',
+      () => 'x'.repeat(65),
+      () => 'contains space',
+      () => 'non-ascii-é',
+      () => 'trailing-newline\n',
+      () => { throw new Error('factory failed'); },
+    ];
+
+    for (const createMatchId of invalidFactories) {
+      let seedCalls = 0;
+      const registry = registryHarness({
+        createMatchId,
+        createMatchSeed() { seedCalls += 1; return MATCH_SEED; },
+      });
+      prepareSecondReady(registry);
+
+      assert.throws(
+        () => registry.setPlayerReady({
+          code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3,
+        }),
+        (error) => error?.code === 'invalid_match_id',
+      );
+
+      const unchanged = registry.getRoom('ABC234');
+      assert.equal(seedCalls, 0);
+      assert.equal(unchanged.seq, 3);
+      assert.equal(unchanged.players[1].ready, false);
+      assert.equal(Object.hasOwn(unchanged, 'match'), false);
+    }
+  });
+
+  it('allocates and validates match authority before mutating readiness or sequence', () => {
+    let registry;
+    const observedFactoryStates = [];
+    function observeState() {
+      observedFactoryStates.push(registry.getRoom('ABC234'));
+    }
+    registry = registryHarness({
+      createMatchId() { observeState(); return MATCH_ID; },
+      createMatchSeed() { observeState(); return MATCH_SEED; },
+    });
+    prepareSecondReady(registry);
+
+    const started = registry.setPlayerReady({
+      code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3,
+    });
+
+    assert.equal(observedFactoryStates.length, 2);
+    for (const observed of observedFactoryStates) {
+      assert.equal(observed.seq, 3);
+      assert.equal(observed.players[1].ready, false);
+      assert.equal(Object.hasOwn(observed, 'match'), false);
+    }
+    assert.deepEqual(started.match, { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 });
+  });
+
+  it('rejects every readiness request after a match starts without mutation', () => {
+    const registry = registryHarness();
+    const started = startMatch(registry);
+    const before = registry.getRoom('ABC234');
+    assert.deepEqual(started.match, { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 });
+
+    for (const ready of [true, false]) {
+      assert.throws(
+        () => registry.setPlayerReady({
+          code: 'ABC234', playerId: 'p1', ready, expectedSeq: 4,
+        }),
+        (error) => error?.code === 'match_started',
+      );
+      assert.deepEqual(registry.getRoom('ABC234'), before);
+    }
+  });
+});

--- a/tests/multiplayer-match-start.test.mjs
+++ b/tests/multiplayer-match-start.test.mjs
@@ -1,0 +1,350 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import vm from 'node:vm';
+import { createRoomProtocol } from '../room-protocol.js';
+import { createRoomRegistry } from '../room-registry.js';
+
+const root = new URL('..', import.meta.url);
+const read = (relative) => fs.readFile(new URL(relative, root), 'utf8');
+const MATCH_ID = 'match-1';
+const MATCH_SEED = 0x12345678;
+
+function sequence(values) {
+  let index = 0;
+  return () => values[index++];
+}
+
+function registryHarness(overrides = {}) {
+  return createRoomRegistry({
+    generateCode: () => 'ABC234',
+    createPlayerId: sequence(['p1', 'p2']),
+    createMatchId: () => MATCH_ID,
+    createMatchSeed: () => MATCH_SEED,
+    ...overrides,
+  });
+}
+
+function prepareTwoPlayerRoom(registry) {
+  const created = registry.createRoom({ name: 'Alpha' });
+  assert.equal(Object.hasOwn(created.room, 'match'), false);
+  const joined = registry.joinRoom({ code: 'ABC234', name: 'Beta' });
+  assert.equal(joined.room.seq, 2);
+  assert.equal(Object.hasOwn(joined.room, 'match'), false);
+  return joined.room;
+}
+
+function request(type, requestId, fields = {}) {
+  return JSON.stringify({ type, requestId, ...fields });
+}
+
+function createElement(id = '') {
+  const listeners = new Map();
+  const classes = new Set();
+  return {
+    id,
+    value: '',
+    textContent: '',
+    disabled: false,
+    children: [],
+    style: {},
+    classList: {
+      add(name) { classes.add(name); },
+      remove(name) { classes.delete(name); },
+      contains(name) { return classes.has(name); },
+    },
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || [];
+      current.push(listener);
+      listeners.set(type, current);
+    },
+    appendChild(child) { this.children.push(child); },
+    async dispatch(type, event = {}) {
+      for (const listener of listeners.get(type) || []) await listener(event);
+    },
+  };
+}
+
+function runRoomClient(source) {
+  const elements = new Map();
+  const browserEvents = [];
+  let socket;
+  const getElement = (id) => {
+    if (!elements.has(id)) elements.set(id, createElement(id));
+    return elements.get(id);
+  };
+
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.listeners = new Map();
+      socket = this;
+    }
+    addEventListener(type, listener) {
+      const current = this.listeners.get(type) || [];
+      current.push(listener);
+      this.listeners.set(type, current);
+    }
+    send() {}
+    async emit(type, event = {}) {
+      for (const listener of this.listeners.get(type) || []) await listener(event);
+    }
+  }
+
+  class FakeCustomEvent {
+    constructor(type, init = {}) {
+      this.type = type;
+      this.detail = init.detail;
+    }
+  }
+
+  const windowListeners = new Map();
+  const location = {
+    protocol: 'https:',
+    host: 'game.example',
+    origin: 'https://game.example',
+    pathname: '/play',
+    search: '',
+  };
+  const windowObject = {
+    location,
+    CustomEvent: FakeCustomEvent,
+    addEventListener(type, listener) {
+      const current = windowListeners.get(type) || [];
+      current.push(listener);
+      windowListeners.set(type, current);
+    },
+    dispatchEvent(event) {
+      browserEvents.push(event);
+      for (const listener of windowListeners.get(event.type) || []) listener(event);
+      return true;
+    },
+  };
+  const sandbox = {
+    window: windowObject,
+    document: {
+      body: { appendChild() {}, removeChild() {} },
+      execCommand: () => false,
+      getElementById: getElement,
+      createElement: () => createElement(),
+    },
+    navigator: {},
+    crypto: { randomUUID: () => 'request-id' },
+    WebSocket: FakeWebSocket,
+    CustomEvent: FakeCustomEvent,
+    URL,
+    URLSearchParams,
+    Uint8Array,
+    console,
+  };
+
+  vm.runInNewContext(source, sandbox, { filename: 'room-client.js' });
+  return { browserEvents, getElement, socket };
+}
+
+function runGame(source) {
+  const executable = source.replace(/^import .*;\s*$/gm, '');
+  const elements = new Map();
+  const generatedSeeds = [];
+  const windowListeners = new Map();
+  const getElement = (id) => {
+    if (!elements.has(id)) {
+      const element = createElement(id);
+      if (id === 'game') {
+        element.width = 300;
+        element.height = 600;
+        element.getContext = () => ({
+          clearRect() {}, fillRect() {}, strokeRect() {}, fillText() {},
+          beginPath() {}, moveTo() {}, lineTo() {}, stroke() {},
+          save() {}, restore() {}, translate() {}, scale() {},
+        });
+      }
+      elements.set(id, element);
+    }
+    return elements.get(id);
+  };
+  const windowObject = {
+    addEventListener(type, listener) {
+      const current = windowListeners.get(type) || [];
+      current.push(listener);
+      windowListeners.set(type, current);
+    },
+    dispatchEvent(event) {
+      for (const listener of windowListeners.get(event.type) || []) listener(event);
+      return true;
+    },
+  };
+  const pieceTypes = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
+  let pieceIndex = 0;
+  const sandbox = {
+    window: windowObject,
+    document: {
+      documentElement: {},
+      getElementById: getElement,
+      createElement: () => createElement(),
+      addEventListener() {},
+      querySelectorAll: () => [],
+    },
+    localStorage: { getItem: () => null, setItem() {} },
+    crypto: { getRandomValues(array) { array[0] = 7; return array; } },
+    Uint32Array,
+    Audio: class {
+      play() { return Promise.resolve(); }
+      pause() {}
+    },
+    createSeededPieceSource(seed) {
+      generatedSeeds.push(seed);
+      return { next: () => pieceTypes[(pieceIndex++) % pieceTypes.length] };
+    },
+    createThemeRainBootstrap: () => ({ start() {}, dispose() {} }),
+    computePreviewFrameLayout: () => ({}),
+    drawPreviewFrame() {},
+    bindIosDoubleTapGuard() {},
+    scoreDrop: () => 0,
+    scoreLineClear: () => 0,
+    describeLevelChange: () => '',
+    getProgression: () => ({ level: 1, dropIntervalMs: 1000, progressText: '0/10' }),
+    requestAnimationFrame() {},
+    performance: { now: () => 0 },
+    prompt: () => null,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    setInterval,
+    clearInterval,
+    console,
+  };
+  vm.runInNewContext(executable, sandbox, { filename: 'game.js' });
+  return { elements, generatedSeeds, window: windowObject };
+}
+
+function matchState(match = { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 }) {
+  return {
+    type: 'room_state',
+    room: {
+      code: 'ABC234',
+      seq: 4,
+      players: [
+        { id: 'p1', name: 'Alpha', ready: true },
+        { id: 'p2', name: 'Beta', ready: true },
+      ],
+      match,
+    },
+    self: { playerId: 'p1' },
+  };
+}
+
+describe('Pass 02 server-authoritative match start', () => {
+  it('creates one detached match atomically on the second Ready transition', () => {
+    let idCalls = 0;
+    let seedCalls = 0;
+    const registry = registryHarness({
+      createMatchId() { idCalls += 1; return MATCH_ID; },
+      createMatchSeed() { seedCalls += 1; return MATCH_SEED; },
+    });
+    prepareTwoPlayerRoom(registry);
+
+    const firstReady = registry.setPlayerReady({
+      code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2,
+    });
+    assert.equal(firstReady.seq, 3);
+    assert.equal(Object.hasOwn(firstReady, 'match'), false);
+    assert.equal(idCalls, 0);
+    assert.equal(seedCalls, 0);
+
+    const started = registry.setPlayerReady({
+      code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3,
+    });
+    assert.equal(started.seq, 4);
+    assert.deepEqual(started.match, { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 });
+    assert.equal(idCalls, 1);
+    assert.equal(seedCalls, 1);
+
+    started.match.seed = 1;
+    assert.equal(registry.getRoom('ABC234').match.seed, MATCH_SEED);
+    assert.throws(
+      () => registry.setPlayerReady({ code: 'ABC234', playerId: 'p1', ready: false, expectedSeq: 4 }),
+      (error) => error?.code === 'match_started',
+    );
+    assert.equal(registry.getRoom('ABC234').seq, 4);
+    assert.equal(registry.getRoom('ABC234').match.seed, MATCH_SEED);
+  });
+
+  it('uses cryptographic defaults and rejects malformed seed authority without mutation', async () => {
+    const source = await read('room-registry.js');
+    assert.match(source, /from\s+["']node:crypto["']/);
+    assert.match(source, /\b(?:randomBytes|randomInt|webcrypto)\b/);
+    assert.doesNotMatch(source, /Math\.random|Date\.now/);
+
+    const registry = registryHarness({ createMatchSeed: () => -1 });
+    prepareTwoPlayerRoom(registry);
+    registry.setPlayerReady({ code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2 });
+    assert.throws(
+      () => registry.setPlayerReady({ code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3 }),
+      (error) => error?.code === 'invalid_match_seed',
+    );
+    const unchanged = registry.getRoom('ABC234');
+    assert.equal(unchanged.seq, 3);
+    assert.equal(unchanged.players[1].ready, false);
+    assert.equal(Object.hasOwn(unchanged, 'match'), false);
+  });
+
+  it('broadcasts the identical authoritative match snapshot to both sessions', () => {
+    const sent = [];
+    const protocol = createRoomProtocol({
+      registry: registryHarness(),
+      send(connectionId, message) { sent.push({ connectionId, message }); },
+    });
+    protocol.connect('c1');
+    protocol.connect('c2');
+    protocol.receive('c1', request('create_room', 'r1', { name: 'Alpha' }));
+    protocol.receive('c2', request('join_room', 'r2', { code: 'ABC234', name: 'Beta' }));
+    protocol.receive('c1', request('set_ready', 'r3', { ready: true, expectedSeq: 2 }));
+    sent.length = 0;
+
+    protocol.receive('c2', request('set_ready', 'r4', { ready: true, expectedSeq: 3 }));
+    assert.equal(sent.length, 2);
+    assert.deepEqual(sent.map(({ connectionId }) => connectionId), ['c1', 'c2']);
+    assert.deepEqual(sent[0].message.room.match, { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 });
+    assert.deepEqual(sent[1].message.room.match, sent[0].message.room.match);
+    assert.notEqual(sent[0].message.room.match, sent[1].message.room.match);
+  });
+
+  it('dispatches one validated browser start event and disables lobby readiness', async () => {
+    const app = runRoomClient(await read('public/room-client.js'));
+    const state = matchState();
+    await app.socket.emit('message', { data: JSON.stringify(state) });
+    await app.socket.emit('message', { data: JSON.stringify(state) });
+
+    const starts = app.browserEvents.filter((event) => event.type === 'stacklogic:match-start');
+    assert.equal(starts.length, 1);
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(starts[0].detail)),
+      { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    );
+    assert.equal(app.getElement('roomReadyBtn').disabled, true);
+    assert.match(app.getElement('roomReadyBtn').textContent, /started/i);
+
+    await app.socket.emit('message', {
+      data: JSON.stringify(matchState({ id: 'invalid-next', seed: -1, startedSeq: 4 })),
+    });
+    assert.equal(
+      app.browserEvents.filter((event) => event.type === 'stacklogic:match-start').length,
+      1,
+    );
+  });
+
+  it('starts the existing game seam with the server seed while preserving solo Start', async () => {
+    const source = await read('public/game.js');
+    const multiplayer = runGame(source);
+    assert.deepEqual(multiplayer.generatedSeeds, [7]);
+    multiplayer.window.dispatchEvent({
+      type: 'stacklogic:match-start',
+      detail: { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    });
+    assert.deepEqual(multiplayer.generatedSeeds, [7, MATCH_SEED]);
+    assert.equal(multiplayer.elements.get('title').classList.contains('show'), false);
+
+    const solo = runGame(source);
+    await solo.elements.get('startBtn').dispatch('click');
+    assert.deepEqual(solo.generatedSeeds, [7, 7]);
+  });
+});

--- a/tests/multiplayer-opponent-state.test.mjs
+++ b/tests/multiplayer-opponent-state.test.mjs
@@ -1,0 +1,814 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import vm from 'node:vm';
+import { createRoomProtocol } from '../room-protocol.js';
+import { createRoomRegistry } from '../room-registry.js';
+
+const root = new URL('..', import.meta.url);
+const read = (relative) => fs.readFile(new URL(relative, root), 'utf8');
+const MATCH_ID = 'match-1';
+const MATCH_SEED = 0x12345678;
+const PIECES = new Set(['I', 'O', 'T', 'S', 'Z', 'J', 'L']);
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function sequence(values) {
+  let index = 0;
+  return () => values[index++];
+}
+
+function makeBoard(entries = []) {
+  const board = Array.from({ length: 20 }, () => Array(10).fill(null));
+  for (const [row, column, piece] of entries) board[row][column] = piece;
+  return board;
+}
+
+function makeState(overrides = {}) {
+  return {
+    board: makeBoard(),
+    score: 0,
+    lines: 0,
+    gameOver: false,
+    ...overrides,
+  };
+}
+
+function registryHarness() {
+  return createRoomRegistry({
+    generateCode: () => 'ABC234',
+    createPlayerId: sequence(['p1', 'p2']),
+    createMatchId: () => MATCH_ID,
+    createMatchSeed: () => MATCH_SEED,
+  });
+}
+
+function prepareStartedRegistry(registry) {
+  registry.createRoom({ name: 'Alpha' });
+  registry.joinRoom({ code: 'ABC234', name: 'Beta' });
+  registry.setPlayerReady({ code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2 });
+  return registry.setPlayerReady({ code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3 });
+}
+
+function request(type, requestId, fields = {}) {
+  return JSON.stringify({ type, requestId, ...fields });
+}
+
+function prepareStartedProtocol(protocol, sent) {
+  protocol.connect('c1');
+  protocol.connect('c2');
+  protocol.receive('c1', request('create_room', 'r1', { name: 'Alpha' }));
+  protocol.receive('c2', request('join_room', 'r2', { code: 'ABC234', name: 'Beta' }));
+  protocol.receive('c1', request('set_ready', 'r3', { ready: true, expectedSeq: 2 }));
+  protocol.receive('c2', request('set_ready', 'r4', { ready: true, expectedSeq: 3 }));
+  sent.length = 0;
+}
+
+function createElement(id = '') {
+  const listeners = new Map();
+  const classes = new Set();
+  const attributes = new Map();
+  return {
+    id,
+    value: '',
+    textContent: '',
+    disabled: false,
+    hidden: id === 'opponentPanel',
+    children: [],
+    style: {},
+    parentNode: null,
+    classList: {
+      add(name) { classes.add(name); },
+      remove(name) { classes.delete(name); },
+      contains(name) { return classes.has(name); },
+    },
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || [];
+      current.push(listener);
+      listeners.set(type, current);
+    },
+    appendChild(child) { child.parentNode = this; this.children.push(child); },
+    removeChild(child) { this.children = this.children.filter((item) => item !== child); child.parentNode = null; },
+    select() {},
+    focus() {},
+    closest() { return null; },
+    getAttribute(name) { return attributes.get(name) ?? null; },
+    setAttribute(name, value) { attributes.set(name, String(value)); },
+    async dispatch(type, event = {}) {
+      for (const listener of listeners.get(type) || []) await listener(event);
+    },
+  };
+}
+
+class FakeCustomEvent {
+  constructor(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail;
+  }
+}
+
+function runRoomClient(source) {
+  const elements = new Map();
+  const browserEvents = [];
+  const sentMessages = [];
+  const windowListeners = new Map();
+  let socket;
+  let requestCounter = 0;
+
+  const getElement = (id) => {
+    if (!elements.has(id)) elements.set(id, createElement(id));
+    return elements.get(id);
+  };
+
+  class FakeWebSocket {
+    static OPEN = 1;
+    constructor(url) {
+      this.url = url;
+      this.listeners = new Map();
+      this.readyState = FakeWebSocket.OPEN;
+      socket = this;
+    }
+    addEventListener(type, listener) {
+      const current = this.listeners.get(type) || [];
+      current.push(listener);
+      this.listeners.set(type, current);
+    }
+    send(raw) { sentMessages.push(JSON.parse(raw)); }
+    async emit(type, event = {}) {
+      if (type === 'close') this.readyState = 3;
+      for (const listener of this.listeners.get(type) || []) await listener(event);
+    }
+  }
+
+  const location = {
+    protocol: 'https:',
+    host: 'game.example',
+    origin: 'https://game.example',
+    pathname: '/play',
+    search: '',
+  };
+  const windowObject = {
+    location,
+    CustomEvent: FakeCustomEvent,
+    addEventListener(type, listener) {
+      const current = windowListeners.get(type) || [];
+      current.push(listener);
+      windowListeners.set(type, current);
+    },
+    dispatchEvent(event) {
+      browserEvents.push(event);
+      for (const listener of windowListeners.get(event.type) || []) listener(event);
+      return true;
+    },
+  };
+  const sandbox = {
+    window: windowObject,
+    document: {
+      body: createElement('body'),
+      execCommand: () => false,
+      getElementById: getElement,
+      createElement: () => createElement(),
+    },
+    navigator: {},
+    crypto: { randomUUID: () => `request-${++requestCounter}` },
+    WebSocket: FakeWebSocket,
+    CustomEvent: FakeCustomEvent,
+    URL,
+    URLSearchParams,
+    Uint8Array,
+    console,
+  };
+
+  vm.runInNewContext(source, sandbox, { filename: 'room-client.js' });
+  return { browserEvents, getElement, sentMessages, socket, window: windowObject };
+}
+
+function matchState(selfPlayerId = 'p1') {
+  return {
+    type: 'room_state',
+    protocolVersion: 1,
+    room: {
+      code: 'ABC234',
+      seq: 4,
+      players: [
+        { id: 'p1', name: 'Alpha', ready: true },
+        { id: 'p2', name: 'Beta', ready: true },
+      ],
+      match: { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    },
+    self: { playerId: selfPlayerId },
+  };
+}
+
+function runGame(source) {
+  const executable = source.replace(/^import .*;\s*$/gm, '');
+  const elements = new Map();
+  const browserEvents = [];
+  const drawCalls = [];
+  const windowListeners = new Map();
+  const documentListeners = new Map();
+
+  const getElement = (id) => {
+    if (!elements.has(id)) {
+      const element = createElement(id);
+      if (id === 'game' || id === 'opponentGame') {
+        element.width = id === 'game' ? 300 : 120;
+        element.height = id === 'game' ? 600 : 240;
+        const context = {
+          clearRect(...args) { drawCalls.push({ kind: 'clear', id, args }); },
+          fillRect() {},
+          strokeRect() {},
+          fillText() {},
+          beginPath() {},
+          moveTo() {},
+          lineTo() {},
+          stroke() {},
+          save() {},
+          restore() {},
+          translate() {},
+          scale() {},
+        };
+        element.getContext = () => context;
+      }
+      elements.set(id, element);
+    }
+    return elements.get(id);
+  };
+
+  const windowObject = {
+    addEventListener(type, listener) {
+      const current = windowListeners.get(type) || [];
+      current.push(listener);
+      windowListeners.set(type, current);
+    },
+    dispatchEvent(event) {
+      browserEvents.push(event);
+      for (const listener of windowListeners.get(event.type) || []) listener(event);
+      return true;
+    },
+  };
+  const documentObject = {
+    documentElement: {},
+    getElementById: getElement,
+    createElement: () => createElement(),
+    querySelectorAll: () => [],
+    addEventListener(type, listener) {
+      const current = documentListeners.get(type) || [];
+      current.push(listener);
+      documentListeners.set(type, current);
+    },
+    async dispatch(type, event = {}) {
+      for (const listener of documentListeners.get(type) || []) await listener(event);
+    },
+  };
+
+  const sandbox = {
+    window: windowObject,
+    document: documentObject,
+    CustomEvent: FakeCustomEvent,
+    localStorage: { getItem: () => null, setItem() {} },
+    crypto: { getRandomValues(array) { array[0] = 7; return array; } },
+    Uint32Array,
+    Audio: class {
+      play() { return Promise.resolve(); }
+      pause() {}
+    },
+    createSeededPieceSource() {
+      const pieceTypes = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
+      let pieceIndex = 0;
+      return { next: () => pieceTypes[(pieceIndex++) % pieceTypes.length] };
+    },
+    createThemeRainBootstrap: () => ({ start() {}, dispose() {} }),
+    computePreviewFrameLayout: () => ({}),
+    drawPreviewFrame() {},
+    drawBrick(context, x, y, color, theme, size) {
+      drawCalls.push({ kind: 'brick', context, x, y, color, theme, size });
+    },
+    drawBrickAt(context, x, y, color, theme, size) {
+      drawCalls.push({ kind: 'brick-at', context, x, y, color, theme, size });
+    },
+    bindIosDoubleTapGuard() {},
+    scoreDrop: (kind, distance) => kind === 'hard' ? distance * 2 : distance,
+    scoreLineClear: () => 0,
+    describeLevelChange: () => '',
+    getProgression: () => ({ level: 1, dropIntervalMs: 1000, progressText: '0/10' }),
+    requestAnimationFrame() {},
+    performance: { now: () => 0 },
+    prompt: () => null,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    setInterval,
+    clearInterval,
+    console,
+  };
+
+  vm.runInNewContext(executable, sandbox, { filename: 'game.js' });
+  return { browserEvents, document: documentObject, drawCalls, elements, getElement, window: windowObject };
+}
+
+function localStateEvents(app) {
+  return app.browserEvents.filter((event) => event.type === 'stacklogic:local-state');
+}
+
+function multiplayerEndEvents(app) {
+  return app.browserEvents.filter((event) => event.type === 'stacklogic:multiplayer-end');
+}
+
+describe('Pass 03 live opponent state', () => {
+  it('stores only detached, valid, exactly sequenced player state without advancing room sequence', () => {
+    const registry = registryHarness();
+    const started = prepareStartedRegistry(registry);
+    assert.equal(started.seq, 4);
+
+    const pristine = registry.getRoom('ABC234');
+    assert.throws(
+      () => registry.updatePlayerState({
+        code: 'ABC234',
+        playerId: 'p1',
+        matchId: MATCH_ID,
+        updateSeq: 2,
+        state: makeState(),
+      }),
+      (error) => {
+        assert.equal(error?.code, 'stale_player_state');
+        assert.equal(error.currentUpdateSeq, 0);
+        return true;
+      },
+    );
+    assert.deepEqual(registry.getRoom('ABC234'), pristine);
+
+    const state = makeState({
+      board: makeBoard([[19, 4, 'T']]),
+      score: 24,
+      lines: 2,
+    });
+    const updated = registry.updatePlayerState({
+      code: 'ABC234',
+      playerId: 'p1',
+      matchId: MATCH_ID,
+      updateSeq: 1,
+      state,
+    });
+
+    assert.equal(updated.seq, 4);
+    assert.deepEqual(updated.players[0].gameState, { updateSeq: 1, ...state });
+    state.board[19][4] = 'I';
+    updated.players[0].gameState.board[19][4] = 'O';
+    assert.equal(registry.getRoom('ABC234').players[0].gameState.board[19][4], 'T');
+
+    const before = registry.getRoom('ABC234');
+    const invalidCases = [
+      [{ matchId: 'foreign-match', updateSeq: 2, state: makeState() }, 'match_mismatch'],
+      [{ matchId: MATCH_ID, updateSeq: 0, state: makeState() }, 'invalid_update_sequence'],
+      [{ matchId: MATCH_ID, updateSeq: 1, state: makeState() }, 'stale_player_state'],
+      [{ matchId: MATCH_ID, updateSeq: 3, state: makeState() }, 'stale_player_state'],
+      [{ matchId: MATCH_ID, updateSeq: 2, state: makeState({ board: makeBoard().slice(1) }) }, 'invalid_player_state'],
+      [{ matchId: MATCH_ID, updateSeq: 2, state: makeState({ board: makeBoard([[0, 0, 'X']]) }) }, 'invalid_player_state'],
+      [{ matchId: MATCH_ID, updateSeq: 2, state: makeState({ score: Number.MAX_SAFE_INTEGER }) }, 'invalid_player_state'],
+      [{ matchId: MATCH_ID, updateSeq: 2, state: { ...makeState(), extra: true } }, 'invalid_player_state'],
+    ];
+    for (const [fields, code] of invalidCases) {
+      assert.throws(
+        () => registry.updatePlayerState({ code: 'ABC234', playerId: 'p1', ...fields }),
+        (error) => {
+          assert.equal(error?.code, code);
+          if (code === 'stale_player_state') assert.equal(error.currentUpdateSeq, 1);
+          return true;
+        },
+      );
+      assert.deepEqual(registry.getRoom('ABC234'), before);
+    }
+
+    const inheritedRequiredField = Object.assign(Object.create({ gameOver: false }), {
+      board: makeBoard(),
+      score: 0,
+      lines: 0,
+      extra: true,
+    });
+    assert.throws(
+      () => registry.updatePlayerState({
+        code: 'ABC234',
+        playerId: 'p1',
+        matchId: MATCH_ID,
+        updateSeq: 2,
+        state: inheritedRequiredField,
+      }),
+      (error) => error?.code === 'invalid_player_state',
+    );
+    assert.deepEqual(registry.getRoom('ABC234'), before);
+  });
+
+  it('acknowledges the sender, relays a detached opponent projection, and fails closed without broadcast', () => {
+    const sent = [];
+    const registry = registryHarness();
+    const protocol = createRoomProtocol({
+      registry,
+      send(connectionId, message) { sent.push({ connectionId, message }); },
+    });
+    prepareStartedProtocol(protocol, sent);
+
+    const state = makeState({ board: makeBoard([[19, 4, 'T']]), score: 36, lines: 3 });
+    protocol.receive('c1', request('update_player_state', 'u1', {
+      matchId: MATCH_ID,
+      updateSeq: 1,
+      state,
+      playerId: 'p2',
+    }));
+
+    assert.deepEqual(plain(sent), [
+      {
+        connectionId: 'c1',
+        message: {
+          type: 'player_state_accepted',
+          protocolVersion: 1,
+          requestId: 'u1',
+          matchId: MATCH_ID,
+          updateSeq: 1,
+        },
+      },
+      {
+        connectionId: 'c2',
+        message: {
+          type: 'opponent_state',
+          protocolVersion: 1,
+          matchId: MATCH_ID,
+          opponent: { name: 'Alpha', updateSeq: 1, ...state },
+        },
+      },
+    ]);
+    assert.equal(Object.hasOwn(sent[1].message.opponent, 'playerId'), false);
+    sent[1].message.opponent.board[19][4] = 'O';
+    assert.equal(registry.getRoom('ABC234').players[0].gameState.board[19][4], 'T');
+
+    sent.length = 0;
+    protocol.receive('c1', request('update_player_state', 'u2', {
+      matchId: MATCH_ID,
+      updateSeq: 1,
+      state: makeState(),
+    }));
+    assert.deepEqual(plain(sent), [{
+      connectionId: 'c1',
+      message: {
+        type: 'error',
+        protocolVersion: 1,
+        code: 'stale_player_state',
+        currentUpdateSeq: 1,
+        requestId: 'u2',
+      },
+    }]);
+    assert.equal(registry.getRoom('ABC234').players[0].gameState.score, 36);
+
+    for (const [requestId, fields, code] of [
+      ['u3', { matchId: MATCH_ID, updateSeq: '2', state: makeState() }, 'invalid_update_sequence'],
+      ['u4', { matchId: MATCH_ID, updateSeq: 2, state: null }, 'invalid_player_state'],
+    ]) {
+      sent.length = 0;
+      const before = registry.getRoom('ABC234');
+      protocol.receive('c1', request('update_player_state', requestId, fields));
+      assert.deepEqual(plain(sent), [{
+        connectionId: 'c1',
+        message: {
+          type: 'error',
+          protocolVersion: 1,
+          code,
+          requestId,
+        },
+      }]);
+      assert.deepEqual(registry.getRoom('ABC234'), before);
+    }
+  });
+
+  it('bridges only validated active-match local and opponent state with independent exact sequences', async () => {
+    const app = runRoomClient(await read('public/room-client.js'));
+    await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+    app.sentMessages.length = 0;
+
+    const first = makeState({ board: makeBoard([[19, 4, 'I']]), score: 32 });
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...first },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: 'foreign-match', ...makeState() },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...makeState({ board: makeBoard([[0, 0, 'X']]) }) },
+    }));
+    const second = makeState({ board: makeBoard([[19, 3, 'O']]), score: 40, lines: 1 });
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...second },
+    }));
+
+    await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:match-start').length, 1);
+    const third = makeState({ board: makeBoard([[18, 3, 'S']]), score: 44, lines: 1 });
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...third },
+    }));
+
+    assert.equal(app.sentMessages.length, 3);
+    assert.deepEqual(
+      app.sentMessages.map(({ type, matchId, updateSeq, state }) => ({ type, matchId, updateSeq, state })),
+      [
+        { type: 'update_player_state', matchId: MATCH_ID, updateSeq: 1, state: first },
+        { type: 'update_player_state', matchId: MATCH_ID, updateSeq: 2, state: second },
+        { type: 'update_player_state', matchId: MATCH_ID, updateSeq: 3, state: third },
+      ],
+    );
+    first.board[19][4] = 'Z';
+    assert.equal(app.sentMessages[0].state.board[19][4], 'I');
+
+    const opponent1 = {
+      type: 'opponent_state',
+      protocolVersion: 1,
+      matchId: MATCH_ID,
+      opponent: { name: 'Beta', updateSeq: 1, ...makeState({ board: makeBoard([[19, 5, 'T']]), score: 18 }) },
+    };
+    await app.socket.emit('message', { data: JSON.stringify(opponent1) });
+    await app.socket.emit('message', { data: JSON.stringify(opponent1) });
+    await app.socket.emit('message', { data: JSON.stringify({
+      ...opponent1,
+      opponent: { ...opponent1.opponent, updateSeq: 3 },
+    }) });
+    await app.socket.emit('message', { data: JSON.stringify({
+      ...opponent1,
+      matchId: 'foreign-match',
+      opponent: { ...opponent1.opponent, updateSeq: 2 },
+    }) });
+    const opponent2 = {
+      ...opponent1,
+      opponent: { name: 'Beta', updateSeq: 2, ...makeState({ board: makeBoard([[19, 2, 'L']]), score: 28, lines: 2 }) },
+    };
+    await app.socket.emit('message', { data: JSON.stringify(opponent2) });
+
+    const relayed = app.browserEvents.filter((event) => event.type === 'stacklogic:opponent-state');
+    assert.equal(relayed.length, 2);
+    assert.deepEqual(plain(relayed.map((event) => event.detail)), [
+      { matchId: MATCH_ID, opponent: opponent1.opponent },
+      { matchId: MATCH_ID, opponent: opponent2.opponent },
+    ]);
+    opponent2.opponent.board[19][2] = 'Z';
+    assert.equal(relayed[1].detail.opponent.board[19][2], 'L');
+
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:multiplayer-end', {
+      detail: { matchId: MATCH_ID },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...makeState({ score: 99 }) },
+    }));
+    await app.socket.emit('message', { data: JSON.stringify({
+      ...opponent1,
+      opponent: { ...opponent1.opponent, updateSeq: 3 },
+    }) });
+    assert.equal(app.sentMessages.length, 3);
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:opponent-state').length, 2);
+
+    const closed = runRoomClient(await read('public/room-client.js'));
+    await closed.socket.emit('message', { data: JSON.stringify(matchState()) });
+    await closed.socket.emit('close');
+    closed.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...makeState() },
+    }));
+    assert.equal(closed.sentMessages.length, 0);
+  });
+
+  it('ignores malformed browser bridge envelopes without throwing', async () => {
+    const app = runRoomClient(await read('public/room-client.js'));
+    await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+    app.sentMessages.length = 0;
+
+    assert.doesNotThrow(() => app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', { detail: null })));
+    assert.doesNotThrow(() => app.window.dispatchEvent(new FakeCustomEvent('stacklogic:multiplayer-end', { detail: null })));
+    await assert.doesNotReject(() => app.socket.emit('message', { data: 'null' }));
+    await assert.doesNotReject(() => app.socket.emit('message', { data: JSON.stringify({
+      type: 'opponent_state',
+      protocolVersion: 1,
+      matchId: MATCH_ID,
+      opponent: null,
+    }) }));
+
+    assert.equal(app.sentMessages.length, 0);
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:opponent-state').length, 0);
+  });
+
+  it('requires own exact local state keys', async () => {
+    const app = runRoomClient(await read('public/room-client.js'));
+    await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+    app.sentMessages.length = 0;
+
+    const inheritedBoard = Object.create({ board: makeBoard([[19, 0, 'I']]) });
+    Object.assign(inheritedBoard, {
+      matchId: MATCH_ID,
+      score: 10,
+      lines: 1,
+      gameOver: false,
+      extra: true,
+    });
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', { detail: inheritedBoard }));
+
+    assert.equal(app.sentMessages.length, 0);
+  });
+
+  it('reports meaningful multiplayer transitions and renders one responsive hidden-by-default opponent panel', async () => {
+    const [gameSource, indexHtml, style] = await Promise.all([
+      read('public/game.js'),
+      read('public/index.html'),
+      read('public/style.css'),
+    ]);
+    assert.match(indexHtml, /<aside[^>]+id="opponentPanel"[^>]+hidden/);
+    assert.match(indexHtml, /<canvas[^>]+id="opponentGame"[^>]+width="120"[^>]+height="240"/);
+    for (const id of ['opponentName', 'opponentScore', 'opponentLines', 'opponentStatus']) {
+      assert.match(indexHtml, new RegExp(`id="${id}"`));
+    }
+    assert.match(indexHtml, /style\.css\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+    assert.match(indexHtml, /game\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+    assert.match(style, /\.opponent-panel\s*\{/);
+    assert.match(style, /grid-template-columns:\s*220px\s+300px\s+160px/);
+    assert.match(style, /@media\s*\(max-width:\s*760px\)[\s\S]*\.opponent-panel/);
+
+    const solo = runGame(gameSource);
+    assert.equal(solo.getElement('opponentPanel').hidden, true);
+    assert.equal(localStateEvents(solo).length, 0);
+    await solo.getElement('startBtn').dispatch('click');
+    assert.equal(localStateEvents(solo).length, 0);
+    assert.equal(solo.getElement('opponentPanel').hidden, true);
+
+    const multiplayer = runGame(gameSource);
+    multiplayer.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-start', {
+      detail: { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    }));
+    assert.equal(multiplayer.getElement('opponentPanel').hidden, false);
+    assert.equal(multiplayer.getElement('opponentStatus').textContent, 'Waiting for opponent');
+
+    let reports = localStateEvents(multiplayer);
+    assert.equal(reports.length, 1);
+    assert.deepEqual(plain(reports[0].detail), {
+      matchId: MATCH_ID,
+      board: makeBoard(),
+      score: 0,
+      lines: 0,
+      gameOver: false,
+    });
+
+    await multiplayer.document.dispatch('keydown', { key: 'ArrowLeft' });
+    await multiplayer.document.dispatch('keydown', { key: 'ArrowUp' });
+    assert.equal(localStateEvents(multiplayer).length, 1);
+
+    await multiplayer.document.dispatch('keydown', { key: ' ', preventDefault() {} });
+    reports = localStateEvents(multiplayer);
+    assert.equal(reports.length, 2);
+    assert.equal(reports[1].detail.matchId, MATCH_ID);
+    assert.equal(reports[1].detail.gameOver, false);
+    assert.ok(reports[1].detail.score > 0);
+    assert.equal(reports[1].detail.board.flat().filter((cell) => PIECES.has(cell)).length, 4);
+
+    const opponentBoard = makeBoard([[19, 4, 'T']]);
+    multiplayer.window.dispatchEvent(new FakeCustomEvent('stacklogic:opponent-state', {
+      detail: {
+        matchId: MATCH_ID,
+        opponent: { name: 'Beta', updateSeq: 1, board: opponentBoard, score: 18, lines: 2, gameOver: false },
+      },
+    }));
+    assert.equal(multiplayer.getElement('opponentName').textContent, 'Beta');
+    assert.equal(multiplayer.getElement('opponentScore').textContent, '18');
+    assert.equal(multiplayer.getElement('opponentLines').textContent, '2');
+    assert.equal(multiplayer.getElement('opponentStatus').textContent, 'Playing');
+    assert.ok(multiplayer.drawCalls.some((call) => call.kind === 'brick-at' || call.kind === 'brick'));
+
+    multiplayer.window.dispatchEvent(new FakeCustomEvent('stacklogic:opponent-state', {
+      detail: {
+        matchId: MATCH_ID,
+        opponent: { name: 'Bad', updateSeq: 2, board: makeBoard([[0, 0, 'X']]), score: 99, lines: 9, gameOver: true },
+      },
+    }));
+    assert.equal(multiplayer.getElement('opponentName').textContent, 'Beta');
+    assert.equal(multiplayer.getElement('opponentScore').textContent, '18');
+
+    const reportsBeforeHome = localStateEvents(multiplayer).length;
+    await multiplayer.document.dispatch('keydown', { key: 'r' });
+    assert.equal(multiplayer.getElement('opponentPanel').hidden, true);
+    assert.deepEqual(plain(multiplayerEndEvents(multiplayer).map((event) => event.detail)), [{ matchId: MATCH_ID }]);
+    assert.equal(localStateEvents(multiplayer).length, reportsBeforeHome);
+
+    const drawsBeforeStaleOpponent = multiplayer.drawCalls.length;
+    multiplayer.window.dispatchEvent(new FakeCustomEvent('stacklogic:opponent-state', {
+      detail: {
+        matchId: MATCH_ID,
+        opponent: { name: 'Beta', updateSeq: 2, board: makeBoard([[19, 3, 'L']]), score: 28, lines: 3, gameOver: false },
+      },
+    }));
+    assert.equal(multiplayer.getElement('opponentPanel').hidden, true);
+    assert.equal(multiplayer.drawCalls.length, drawsBeforeStaleOpponent);
+
+    await multiplayer.getElement('startBtn').dispatch('click');
+    assert.equal(multiplayer.getElement('opponentPanel').hidden, true);
+    assert.equal(multiplayerEndEvents(multiplayer).length, 1);
+    assert.equal(localStateEvents(multiplayer).length, reportsBeforeHome);
+  });
+
+  it('bridges only exact active-match result and rematch envelopes', async () => {
+    const app = runRoomClient(await read('public/room-client.js'));
+    await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+    const result = { type: 'match_result', protocolVersion: 1, matchId: MATCH_ID, winnerId: 'p2', loserId: 'p1' };
+    await app.socket.emit('message', { data: JSON.stringify({ ...result, extra: true }) });
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:match-result').length, 0);
+    await app.socket.emit('message', { data: JSON.stringify(result) });
+    assert.deepEqual(plain(app.browserEvents.filter((event) => event.type === 'stacklogic:match-result').map((event) => event.detail)), [{ matchId: MATCH_ID, didWin: false, winnerName: 'Beta' }]);
+
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:rematch-request', { detail: { matchId: MATCH_ID } }));
+    assert.deepEqual(app.sentMessages.map(({ type, matchId }) => ({ type, matchId })), [
+      { type: 'request_rematch', matchId: MATCH_ID },
+    ]);
+    await app.socket.emit('message', { data: JSON.stringify({ type: 'rematch_status', protocolVersion: 1, matchId: MATCH_ID, acceptedPlayerIds: ['p1'], extra: true }) });
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:rematch-status').length, 0);
+    await app.socket.emit('message', { data: JSON.stringify({ type: 'rematch_status', protocolVersion: 1, matchId: MATCH_ID, acceptedPlayerIds: ['p1'] }) });
+    assert.deepEqual(plain(app.browserEvents.filter((event) => event.type === 'stacklogic:rematch-status').map((event) => event.detail)), [{ matchId: MATCH_ID, acceptedPlayerIds: ['p1'] }]);
+  });
+
+  it('clears completed multiplayer state before Home and Solo gameplay', async () => {
+    const app = runGame(await read('public/game.js'));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-start', {
+      detail: { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-result', {
+      detail: { matchId: MATCH_ID, didWin: true, winnerName: 'Alpha' },
+    }));
+
+    assert.equal(app.getElement('opponentPanel').hidden, false);
+    assert.equal(app.getElement('victoryFireworks').hidden, false);
+    assert.equal(app.getElement('rematchBtn').disabled, false);
+
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:rematch-status', {
+      detail: { matchId: 'stale-match', acceptedPlayerIds: ['p2'] },
+    }));
+    assert.equal(app.getElement('rematchBtn').textContent, 'Rematch');
+
+    await app.document.dispatch('keydown', { key: 'r' });
+    assert.equal(app.getElement('opponentPanel').hidden, true);
+    assert.equal(app.getElement('victoryFireworks').hidden, true);
+    assert.equal(app.getElement('rematchBtn').disabled, true);
+    assert.deepEqual(
+      plain(app.browserEvents.filter((event) => event.type === 'stacklogic:multiplayer-abandon').map((event) => event.detail)),
+      [{ matchId: MATCH_ID }],
+    );
+
+    await app.getElement('startBtn').dispatch('click');
+    await app.getElement('rematchBtn').dispatch('click');
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:rematch-request').length, 0);
+  });
+
+  it('treats Rematch acceptance as committed until the next match starts', async () => {
+    const app = runGame(await read('public/game.js'));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-start', {
+      detail: { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-result', {
+      detail: { matchId: MATCH_ID, didWin: true, winnerName: 'Alpha' },
+    }));
+    await app.getElement('rematchBtn').dispatch('click');
+    await app.document.dispatch('keydown', { key: 'r' });
+    await app.getElement('startBtn').dispatch('click');
+
+    assert.equal(app.getElement('gameOver').classList.contains('show'), true);
+    assert.equal(app.getElement('opponentPanel').hidden, false);
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:multiplayer-abandon').length, 0);
+    assert.deepEqual(plain(app.browserEvents.filter((event) => event.type === 'stacklogic:rematch-request').map((event) => event.detail)), [{ matchId: MATCH_ID }]);
+  });
+
+  it('waits for the authoritative result, freezes the match, and preserves the finished ID for rematch', async () => {
+    const app = runGame(await read('public/game.js'));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-start', {
+      detail: { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    }));
+
+    for (let attempt = 0; attempt < 100 && !localStateEvents(app).at(-1)?.detail.gameOver; attempt++) {
+      await app.document.dispatch('keydown', { key: ' ', preventDefault() {} });
+    }
+
+    const reports = localStateEvents(app);
+    assert.ok(reports.length > 1);
+    assert.equal(reports.at(-1).detail.gameOver, true);
+    assert.equal(multiplayerEndEvents(app).length, 0);
+    assert.equal(app.getElement('opponentPanel').hidden, false);
+
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-result', {
+      detail: { matchId: MATCH_ID, didWin: false, winnerName: 'Beta' },
+    }));
+    assert.equal(app.getElement('gameResultTitle').textContent, 'Defeat');
+    assert.match(app.getElement('gameOverText').textContent, /Beta won/);
+    assert.equal(app.getElement('victoryFireworks').hidden, true);
+    assert.equal(app.getElement('opponentStatus').textContent, 'Beta wins! ✦');
+    assert.equal(app.getElement('rematchBtn').disabled, false);
+
+    await app.getElement('rematchBtn').dispatch('click');
+    assert.deepEqual(plain(app.browserEvents.filter((event) => event.type === 'stacklogic:rematch-request').map((event) => event.detail)), [{ matchId: MATCH_ID }]);
+
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:match-start', {
+      detail: { id: 'match-2', seed: 9, startedSeq: 5 },
+    }));
+    assert.equal(app.getElement('gameOver').classList.contains('show'), false);
+    assert.equal(app.getElement('opponentPanel').hidden, false);
+    assert.equal(localStateEvents(app).at(-1).detail.matchId, 'match-2');
+  });
+});

--- a/tests/multiplayer-result-accessibility.test.mjs
+++ b/tests/multiplayer-result-accessibility.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFile } from 'node:fs/promises';
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+describe('Pass 04 result accessibility contract', () => {
+  it('ships a labelled modal result dialog with live result and rematch status surfaces', async () => {
+    const html = await read('public/index.html');
+    assert.match(html, /<div id="gameOver" class="overlay" role="dialog" aria-modal="true" aria-labelledby="gameResultTitle"/);
+    assert.match(html, /<h2 id="gameResultTitle" class="title" aria-live="assertive"/);
+    assert.match(html, /<p class="hint" id="gameOverText" aria-live="polite"/);
+    assert.match(html, /<p id="rematchStatus" class="hint" aria-live="polite"/);
+    assert.match(html, /id="victoryFireworks"[^>]*hidden aria-hidden="true"/);
+  });
+
+  it('suppresses decorative winner animation for reduced-motion users', async () => {
+    const css = await read('public/style.css');
+    assert.match(css, /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.victory-fireworks\s*\{[\s\S]*?animation:\s*none/s);
+  });
+});

--- a/tests/multiplayer-result-rematch.test.mjs
+++ b/tests/multiplayer-result-rematch.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createRoomRegistry } from '../room-registry.js';
+import { createRoomProtocol } from '../room-protocol.js';
+
+const board = () => Array.from({ length: 20 }, () => Array(10).fill(null));
+const state = (gameOver = false) => ({ board: board(), score: 0, lines: 0, gameOver });
+
+function sequence(values) {
+  let index = 0;
+  return () => values[index++];
+}
+
+function started() {
+  const registry = createRoomRegistry({
+    generateCode: () => 'ABC234',
+    createPlayerId: sequence(['p1', 'p2']),
+    createMatchId: sequence(['match-1', 'match-2']),
+    createMatchSeed: sequence([7, 8]),
+  });
+  registry.createRoom({ name: 'Alpha' });
+  registry.joinRoom({ code: 'ABC234', name: 'Beta' });
+  registry.setPlayerReady({ code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2 });
+  registry.setPlayerReady({ code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3 });
+  return registry;
+}
+
+describe('Pass 04 authoritative result and mutual rematch', () => {
+  it('does not commit the final rematch vote when next-match allocation fails', () => {
+    const registry = createRoomRegistry({
+      generateCode: () => 'ABC234',
+      createPlayerId: sequence(['p1', 'p2']),
+      createMatchId: sequence(['match-1', 'invalid match id']),
+      createMatchSeed: sequence([7, 8]),
+    });
+    registry.createRoom({ name: 'Alpha' });
+    registry.joinRoom({ code: 'ABC234', name: 'Beta' });
+    registry.setPlayerReady({ code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2 });
+    registry.setPlayerReady({ code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3 });
+    registry.updatePlayerState({ code: 'ABC234', playerId: 'p1', matchId: 'match-1', updateSeq: 1, state: state(true) });
+    registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' });
+
+    assert.throws(
+      () => registry.requestRematch({ code: 'ABC234', playerId: 'p2', matchId: 'match-1' }),
+      (error) => error?.code === 'invalid_match_state',
+    );
+    assert.deepEqual(registry.getRoom('ABC234').match.rematchAccepted, ['p1']);
+  });
+
+  it('rejects a repeated completed match ID before committing the final rematch vote', () => {
+    const registry = createRoomRegistry({
+      generateCode: () => 'ABC234',
+      createPlayerId: sequence(['p1', 'p2']),
+      createMatchId: sequence(['match-1', 'match-1']),
+      createMatchSeed: sequence([7, 8]),
+    });
+    registry.createRoom({ name: 'Alpha' });
+    registry.joinRoom({ code: 'ABC234', name: 'Beta' });
+    registry.setPlayerReady({ code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2 });
+    registry.setPlayerReady({ code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3 });
+    registry.updatePlayerState({ code: 'ABC234', playerId: 'p1', matchId: 'match-1', updateSeq: 1, state: state(true) });
+    registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' });
+
+    assert.throws(
+      () => registry.requestRematch({ code: 'ABC234', playerId: 'p2', matchId: 'match-1' }),
+      (error) => error?.code === 'invalid_match_state',
+    );
+    assert.deepEqual(registry.getRoom('ABC234').match.rematchAccepted, ['p1']);
+  });
+
+  it('rejects reuse of any historical room match ID before mutation', () => {
+    const registry = createRoomRegistry({
+      generateCode: () => 'ABC234',
+      createPlayerId: sequence(['p1', 'p2']),
+      createMatchId: sequence(['match-1', 'match-2', 'match-1']),
+      createMatchSeed: sequence([7, 8, 9]),
+    });
+    registry.createRoom({ name: 'Alpha' });
+    registry.joinRoom({ code: 'ABC234', name: 'Beta' });
+    registry.setPlayerReady({ code: 'ABC234', playerId: 'p1', ready: true, expectedSeq: 2 });
+    registry.setPlayerReady({ code: 'ABC234', playerId: 'p2', ready: true, expectedSeq: 3 });
+    registry.updatePlayerState({ code: 'ABC234', playerId: 'p1', matchId: 'match-1', updateSeq: 1, state: state(true) });
+    registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' });
+    registry.requestRematch({ code: 'ABC234', playerId: 'p2', matchId: 'match-1' });
+    registry.updatePlayerState({ code: 'ABC234', playerId: 'p1', matchId: 'match-2', updateSeq: 1, state: state(true) });
+    registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-2' });
+
+    assert.throws(
+      () => registry.requestRematch({ code: 'ABC234', playerId: 'p2', matchId: 'match-2' }),
+      (error) => error?.code === 'invalid_match_state',
+    );
+    const room = registry.getRoom('ABC234');
+    assert.equal(room.match.id, 'match-2');
+    assert.deepEqual(room.match.rematchAccepted, ['p1']);
+  });
+
+  it('records exactly one terminal result, fences later state, and starts a fresh match only after both accept rematch', () => {
+    const registry = started();
+    const resolved = registry.updatePlayerState({
+      code: 'ABC234', playerId: 'p1', matchId: 'match-1', updateSeq: 1, state: state(true),
+    });
+    assert.deepEqual(resolved.match.result, { winnerId: 'p2', loserId: 'p1' });
+    assert.throws(() => registry.updatePlayerState({
+      code: 'ABC234', playerId: 'p2', matchId: 'match-1', updateSeq: 1, state: state(false),
+    }), (error) => error?.code === 'match_finished');
+
+    const waiting = registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' });
+    assert.deepEqual(waiting.match.rematchAccepted, ['p1']);
+    const duplicate = registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' });
+    assert.deepEqual(duplicate.match.rematchAccepted, ['p1']);
+    const fresh = registry.requestRematch({ code: 'ABC234', playerId: 'p2', matchId: 'match-1' });
+    assert.deepEqual(fresh.match, { id: 'match-2', seed: 8, startedSeq: fresh.seq });
+    assert.equal(fresh.players.every((player) => !Object.hasOwn(player, 'gameState') && !Object.hasOwn(player, 'currentUpdateSeq')), true);
+  });
+
+  it('fails closed for pre-result, simultaneous-terminal, and stale rematch transitions', () => {
+    const registry = started();
+    assert.throws(() => registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' }), (error) => error?.code === 'match_not_finished');
+
+    registry.updatePlayerState({ code: 'ABC234', playerId: 'p1', matchId: 'match-1', updateSeq: 1, state: state(true) });
+    assert.throws(() => registry.updatePlayerState({ code: 'ABC234', playerId: 'p2', matchId: 'match-1', updateSeq: 1, state: state(true) }), (error) => error?.code === 'match_finished');
+
+    registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' });
+    const fresh = registry.requestRematch({ code: 'ABC234', playerId: 'p2', matchId: 'match-1' });
+    assert.equal(fresh.match.id, 'match-2');
+    assert.throws(() => registry.requestRematch({ code: 'ABC234', playerId: 'p1', matchId: 'match-1' }), (error) => error?.code === 'match_mismatch');
+  });
+
+  it('broadcasts the immutable result and only starts a fresh match after both protocol rematch accepts', () => {
+    const sent = [];
+    const registry = createRoomRegistry({
+      generateCode: () => 'ABC234',
+      createPlayerId: sequence(['p1', 'p2']),
+      createMatchId: sequence(['match-1', 'match-2']),
+      createMatchSeed: sequence([7, 8]),
+    });
+    const protocol = createRoomProtocol({ registry, send: (connectionId, message) => sent.push({ connectionId, message }) });
+    const send = (connectionId, type, requestId, fields = {}) => protocol.receive(connectionId, JSON.stringify({ type, requestId, ...fields }));
+    protocol.connect('c1'); protocol.connect('c2');
+    send('c1', 'create_room', 'r1', { name: 'Alpha' });
+    send('c2', 'join_room', 'r2', { code: 'ABC234', name: 'Beta' });
+    send('c1', 'set_ready', 'r3', { ready: true, expectedSeq: 2 });
+    send('c2', 'set_ready', 'r4', { ready: true, expectedSeq: 3 });
+    sent.length = 0;
+
+    send('c1', 'update_player_state', 'loss-1', { matchId: 'match-1', updateSeq: 1, state: state(true) });
+    const results = sent.filter(({ message }) => message.type === 'match_result');
+    assert.deepEqual(results.map(({ connectionId, message }) => ({ connectionId, message })), [
+      { connectionId: 'c1', message: { type: 'match_result', protocolVersion: 1, matchId: 'match-1', winnerId: 'p2', loserId: 'p1' } },
+      { connectionId: 'c2', message: { type: 'match_result', protocolVersion: 1, matchId: 'match-1', winnerId: 'p2', loserId: 'p1' } },
+    ]);
+
+    sent.length = 0;
+    send('c1', 'request_rematch', 'rematch-1', { matchId: 'match-1' });
+    assert.deepEqual(sent.map(({ message }) => message.type), ['rematch_status', 'rematch_status']);
+    assert.deepEqual(sent[0].message.acceptedPlayerIds, ['p1']);
+
+    sent.length = 0;
+    send('c2', 'request_rematch', 'rematch-2', { matchId: 'match-1' });
+    const starts = sent.filter(({ message }) => message.type === 'room_state').map(({ message }) => message.room.match);
+    assert.deepEqual(starts, [
+      { id: 'match-2', seed: 8, startedSeq: 5 },
+      { id: 'match-2', seed: 8, startedSeq: 5 },
+    ]);
+  });
+
+});

--- a/tests/pass03c-room-client.test.mjs
+++ b/tests/pass03c-room-client.test.mjs
@@ -1,0 +1,295 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { test } from 'node:test';
+import vm from 'node:vm';
+
+const root = new URL('..', import.meta.url);
+const read = (relative) => fs.readFile(new URL(relative, root), 'utf8');
+const MATCH_ID = 'match-1';
+const MATCH_SEED = 0x12345678;
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function makeBoard(entries = []) {
+  const board = Array.from({ length: 20 }, () => Array(10).fill(null));
+  for (const [row, column, piece] of entries) board[row][column] = piece;
+  return board;
+}
+
+function makeState(overrides = {}) {
+  return {
+    board: makeBoard(),
+    score: 0,
+    lines: 0,
+    gameOver: false,
+    ...overrides,
+  };
+}
+
+function createElement(id = '') {
+  const listeners = new Map();
+  const classes = new Set();
+  const attributes = new Map();
+  return {
+    id,
+    value: '',
+    textContent: '',
+    disabled: false,
+    hidden: id === 'opponentPanel',
+    children: [],
+    style: {},
+    parentNode: null,
+    classList: {
+      add(name) { classes.add(name); },
+      remove(name) { classes.delete(name); },
+      contains(name) { return classes.has(name); },
+    },
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || [];
+      current.push(listener);
+      listeners.set(type, current);
+    },
+    appendChild(child) { child.parentNode = this; this.children.push(child); },
+    removeChild(child) { this.children = this.children.filter((item) => item !== child); child.parentNode = null; },
+    select() {},
+    focus() {},
+    closest() { return null; },
+    getAttribute(name) { return attributes.get(name) ?? null; },
+    setAttribute(name, value) { attributes.set(name, String(value)); },
+    async dispatch(type, event = {}) {
+      for (const listener of listeners.get(type) || []) await listener(event);
+    },
+  };
+}
+
+class FakeCustomEvent {
+  constructor(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail;
+  }
+}
+
+function runRoomClient(source) {
+  const elements = new Map();
+  const browserEvents = [];
+  const sentMessages = [];
+  const windowListeners = new Map();
+  let socket;
+  let requestCounter = 0;
+
+  const getElement = (id) => {
+    if (!elements.has(id)) elements.set(id, createElement(id));
+    return elements.get(id);
+  };
+
+  class FakeWebSocket {
+    static OPEN = 1;
+    constructor(url) {
+      this.url = url;
+      this.listeners = new Map();
+      this.readyState = FakeWebSocket.OPEN;
+      socket = this;
+    }
+    addEventListener(type, listener) {
+      const current = this.listeners.get(type) || [];
+      current.push(listener);
+      this.listeners.set(type, current);
+    }
+    send(raw) { sentMessages.push(JSON.parse(raw)); }
+    async emit(type, event = {}) {
+      if (type === 'close') this.readyState = 3;
+      for (const listener of this.listeners.get(type) || []) await listener(event);
+    }
+  }
+
+  const location = {
+    protocol: 'https:',
+    host: 'game.example',
+    origin: 'https://game.example',
+    pathname: '/play',
+    search: '',
+  };
+  const windowObject = {
+    location,
+    CustomEvent: FakeCustomEvent,
+    addEventListener(type, listener) {
+      const current = windowListeners.get(type) || [];
+      current.push(listener);
+      windowListeners.set(type, current);
+    },
+    dispatchEvent(event) {
+      browserEvents.push(event);
+      for (const listener of windowListeners.get(event.type) || []) listener(event);
+      return true;
+    },
+  };
+  const sandbox = {
+    window: windowObject,
+    document: {
+      body: createElement('body'),
+      execCommand: () => false,
+      getElementById: getElement,
+      createElement: () => createElement(),
+    },
+    navigator: {},
+    crypto: { randomUUID: () => `request-${++requestCounter}` },
+    WebSocket: FakeWebSocket,
+    CustomEvent: FakeCustomEvent,
+    URL,
+    URLSearchParams,
+    Uint8Array,
+    console,
+  };
+
+  vm.runInNewContext(source, sandbox, { filename: 'room-client.js' });
+  return { browserEvents, getElement, sentMessages, socket, window: windowObject };
+}
+
+function matchState(selfPlayerId = 'p1') {
+  return {
+    type: 'room_state',
+    protocolVersion: 1,
+    room: {
+      code: 'ABC234',
+      seq: 4,
+      players: [
+        { id: 'p1', name: 'Alpha', ready: true },
+        { id: 'p2', name: 'Beta', ready: true },
+      ],
+      match: { id: MATCH_ID, seed: MATCH_SEED, startedSeq: 4 },
+    },
+    self: { playerId: selfPlayerId },
+  };
+}
+
+test('bridges only validated active-match local and opponent state with independent exact sequences', async () => {
+    const app = runRoomClient(await read('public/room-client.js'));
+    await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+    app.sentMessages.length = 0;
+
+    const first = makeState({ board: makeBoard([[19, 4, 'I']]), score: 32 });
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...first },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: 'foreign-match', ...makeState() },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...makeState({ board: makeBoard([[0, 0, 'X']]) }) },
+    }));
+    const second = makeState({ board: makeBoard([[19, 3, 'O']]), score: 40, lines: 1 });
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...second },
+    }));
+
+    await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:match-start').length, 1);
+    const third = makeState({ board: makeBoard([[18, 3, 'S']]), score: 44, lines: 1 });
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...third },
+    }));
+
+    assert.equal(app.sentMessages.length, 3);
+    assert.deepEqual(
+      app.sentMessages.map(({ type, matchId, updateSeq, state }) => ({ type, matchId, updateSeq, state })),
+      [
+        { type: 'update_player_state', matchId: MATCH_ID, updateSeq: 1, state: first },
+        { type: 'update_player_state', matchId: MATCH_ID, updateSeq: 2, state: second },
+        { type: 'update_player_state', matchId: MATCH_ID, updateSeq: 3, state: third },
+      ],
+    );
+    first.board[19][4] = 'Z';
+    assert.equal(app.sentMessages[0].state.board[19][4], 'I');
+
+    const opponent1 = {
+      type: 'opponent_state',
+      protocolVersion: 1,
+      matchId: MATCH_ID,
+      opponent: { name: 'Beta', updateSeq: 1, ...makeState({ board: makeBoard([[19, 5, 'T']]), score: 18 }) },
+    };
+    await app.socket.emit('message', { data: JSON.stringify(opponent1) });
+    await app.socket.emit('message', { data: JSON.stringify(opponent1) });
+    await app.socket.emit('message', { data: JSON.stringify({
+      ...opponent1,
+      opponent: { ...opponent1.opponent, updateSeq: 3 },
+    }) });
+    await app.socket.emit('message', { data: JSON.stringify({
+      ...opponent1,
+      matchId: 'foreign-match',
+      opponent: { ...opponent1.opponent, updateSeq: 2 },
+    }) });
+    const opponent2 = {
+      ...opponent1,
+      opponent: { name: 'Beta', updateSeq: 2, ...makeState({ board: makeBoard([[19, 2, 'L']]), score: 28, lines: 2 }) },
+    };
+    await app.socket.emit('message', { data: JSON.stringify(opponent2) });
+
+    const relayed = app.browserEvents.filter((event) => event.type === 'stacklogic:opponent-state');
+    assert.equal(relayed.length, 2);
+    assert.deepEqual(plain(relayed.map((event) => event.detail)), [
+      { matchId: MATCH_ID, opponent: opponent1.opponent },
+      { matchId: MATCH_ID, opponent: opponent2.opponent },
+    ]);
+    opponent2.opponent.board[19][2] = 'Z';
+    assert.equal(relayed[1].detail.opponent.board[19][2], 'L');
+
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:multiplayer-end', {
+      detail: { matchId: MATCH_ID },
+    }));
+    app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...makeState({ score: 99 }) },
+    }));
+    await app.socket.emit('message', { data: JSON.stringify({
+      ...opponent1,
+      opponent: { ...opponent1.opponent, updateSeq: 3 },
+    }) });
+    assert.equal(app.sentMessages.length, 3);
+    assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:opponent-state').length, 2);
+
+    const closed = runRoomClient(await read('public/room-client.js'));
+    await closed.socket.emit('message', { data: JSON.stringify(matchState()) });
+    await closed.socket.emit('close');
+    closed.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', {
+      detail: { matchId: MATCH_ID, ...makeState() },
+    }));
+    assert.equal(closed.sentMessages.length, 0);
+});
+
+test('ignores malformed browser bridge envelopes without throwing', async () => {
+  const app = runRoomClient(await read('public/room-client.js'));
+  await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+  app.sentMessages.length = 0;
+
+  assert.doesNotThrow(() => app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', { detail: null })));
+  assert.doesNotThrow(() => app.window.dispatchEvent(new FakeCustomEvent('stacklogic:multiplayer-end', { detail: null })));
+  await assert.doesNotReject(() => app.socket.emit('message', { data: 'null' }));
+  await assert.doesNotReject(() => app.socket.emit('message', { data: JSON.stringify({
+    type: 'opponent_state',
+    protocolVersion: 1,
+    matchId: MATCH_ID,
+    opponent: null,
+  }) }));
+
+  assert.equal(app.sentMessages.length, 0);
+  assert.equal(app.browserEvents.filter((event) => event.type === 'stacklogic:opponent-state').length, 0);
+});
+
+test('requires own exact local state keys', async () => {
+  const app = runRoomClient(await read('public/room-client.js'));
+  await app.socket.emit('message', { data: JSON.stringify(matchState()) });
+  app.sentMessages.length = 0;
+
+  const inheritedBoard = Object.create({ board: makeBoard([[19, 0, 'I']]) });
+  Object.assign(inheritedBoard, {
+    matchId: MATCH_ID,
+    score: 10,
+    lines: 1,
+    gameOver: false,
+    extra: true,
+  });
+  app.window.dispatchEvent(new FakeCustomEvent('stacklogic:local-state', { detail: inheritedBoard }));
+
+  assert.equal(app.sentMessages.length, 0);
+});

--- a/tests/pass03d-layout.test.mjs
+++ b/tests/pass03d-layout.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { test } from 'node:test';
+
+const root = new URL('..', import.meta.url);
+const read = (relative) => fs.readFile(new URL(relative, root), 'utf8');
+
+test('ships an accessible responsive opponent panel with exact cache revisions', async () => {
+  const [html, style] = await Promise.all([
+    read('public/index.html'),
+    read('public/style.css'),
+  ]);
+
+  assert.match(html, /<aside[^>]+id="opponentPanel"[^>]+class="opponent-panel"[^>]+hidden[^>]*aria-labelledby="opponentHeading"/);
+  assert.match(html, /<h2[^>]+id="opponentHeading"[^>]*>Opponent<\/h2>/);
+  assert.match(html, /<canvas[^>]+id="opponentGame"[^>]+width="120"[^>]+height="240"[^>]+aria-label=/);
+  for (const id of ['opponentName', 'opponentScore', 'opponentLines', 'opponentStatus']) {
+    assert.match(html, new RegExp(`id="${id}"`));
+  }
+
+  const hud = html.indexOf('class="hud desktop-only"');
+  const stage = html.indexOf('class="stage"');
+  const opponent = html.indexOf('id="opponentPanel"');
+  assert.ok(hud > -1 && stage > hud && opponent > stage);
+  assert.match(html, /<div id="status" class="status"><\/div>\s*<\/div>\s*<div class="stage">/);
+  assert.match(html, /<div class="mobile-status" id="statusMobile"><\/div>\s*<\/div>\s*<aside id="opponentPanel"/);
+  for (const acceptedId of ['multiplayerLobby', 'startBtn', 'pauseMenu', 'mobileControls']) {
+    assert.match(html, new RegExp(`id="${acceptedId}"`));
+  }
+
+  assert.match(html, /style\.css\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+  assert.match(html, /game\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+  assert.match(html, /room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+
+  assert.match(style, /\.wrap\s*\{[\s\S]*?grid-template-columns:\s*220px\s+300px\s+160px/);
+  assert.match(style, /\.opponent-panel\s*\{[\s\S]*?width:\s*160px/);
+  assert.match(style, /\.opponent-panel\[hidden\]\s*\{\s*display:\s*none/);
+  assert.match(style, /#opponentGame\s*\{[\s\S]*?width:\s*120px[\s\S]*?height:\s*240px/);
+  assert.match(style, /@media\s*\(max-width:\s*760px\)[\s\S]*?\.opponent-panel\s*\{[\s\S]*?justify-self:\s*center/);
+  assert.match(style, /@media\s*\(hover:\s*none\)\s*and\s*\(pointer:\s*coarse\)/);
+  assert.match(style, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+});

--- a/tests/release-metadata.test.mjs
+++ b/tests/release-metadata.test.mjs
@@ -27,9 +27,11 @@ describe('release metadata', () => {
   });
 
   it('cache-busts every shipped CSS and JavaScript entry asset with the release version', () => {
-    for (const asset of ['style.css', 'theme.js', 'theme-renderer.js', 'game.js']) {
+    for (const asset of ['style.css', 'theme.js', 'theme-renderer.js', 'game.js', 'room-client.js']) {
       assert.match(indexHtml, new RegExp(`${asset.replace('.', '\\.') }\\?v=${RELEASE.replaceAll('.', '\\.').replace('-', '\\-')}`));
     }
+
+    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
 
     assert.match(gameJs, /theme-rain-bootstrap\.js\?v=0\.3\.0-beta\.1/);
     assert.match(bootstrapJs, /theme-rain-adapter\.js\?v=0\.3\.0-beta\.1/);

--- a/tests/room-code.test.mjs
+++ b/tests/room-code.test.mjs
@@ -1,0 +1,214 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateRoomCode, normalizePlayerName, ROOM_CODE_ALPHABET } from "../room-code.js";
+
+describe("ROOM_CODE_ALPHABET", () => {
+  it("is a frozen constant with exact value", () => {
+    assert.strictEqual(ROOM_CODE_ALPHABET, "ABCDEFGHJKLMNPQRSTUVWXYZ23456789");
+  });
+
+  it("has length 32", () => {
+    assert.strictEqual(ROOM_CODE_ALPHABET.length, 32);
+  });
+});
+
+describe("generateRoomCode", () => {
+  const alphabet = ROOM_CODE_ALPHABET;
+  const ALPHABET_LEN = alphabet.length; // 32
+
+  function makeRandomBytes(bytes) {
+    return (n) => new Uint8Array(bytes.slice(0, n));
+  }
+
+  it("returns exactly 6 characters from the alphabet", () => {
+    const rb = makeRandomBytes([1, 2, 3, 4, 5, 6]);
+    const code = generateRoomCode(rb);
+    assert.strictEqual(code.length, 6);
+    for (const ch of code) {
+      assert.ok(alphabet.includes(ch), `char '${ch}' not in alphabet`);
+    }
+  });
+
+  it("calls randomBytesFn exactly once with argument 6", () => {
+    let callCount = 0;
+    let lastArg = null;
+    const rb = (n) => {
+      callCount++;
+      lastArg = n;
+      return new Uint8Array(6);
+    };
+    generateRoomCode(rb);
+    assert.strictEqual(callCount, 1);
+    assert.strictEqual(lastArg, 6);
+  });
+
+  it("maps byte 0 -> alphabet[0] = 'A'", () => {
+    const rb = makeRandomBytes([0, 0, 0, 0, 0, 0]);
+    assert.strictEqual(generateRoomCode(rb), "AAAAAA");
+  });
+
+  it("maps byte 31 -> alphabet[31] = '9'", () => {
+    const rb = makeRandomBytes([31, 31, 31, 31, 31, 31]);
+    assert.strictEqual(generateRoomCode(rb), "999999");
+  });
+
+  it("maps byte 32 -> alphabet[0] = 'A' (mod wraps)", () => {
+    const rb = makeRandomBytes([32, 32, 32, 32, 32, 32]);
+    assert.strictEqual(generateRoomCode(rb), "AAAAAA");
+  });
+
+  it("maps byte 255 -> alphabet[31] = '9' (255 % 32 = 31)", () => {
+    const rb = makeRandomBytes([255, 255, 255, 255, 255, 255]);
+    assert.strictEqual(generateRoomCode(rb), "999999");
+  });
+
+  it("throws Error with code 'invalid_entropy' when result has fewer than 6 bytes", () => {
+    const rb = () => new Uint8Array(5);
+    assert.throws(() => generateRoomCode(rb), (err) => {
+      assert.strictEqual(err.code, "invalid_entropy");
+      return true;
+    });
+  });
+
+  it("throws Error with code 'invalid_entropy' when result is not Uint8Array-like", () => {
+    const rb = () => null;
+    assert.throws(() => generateRoomCode(rb), (err) => {
+      assert.strictEqual(err.code, "invalid_entropy");
+      return true;
+    });
+  });
+
+  it("never uses Math.random", () => {
+    const origMathRandom = Math.random;
+    let mathRandomCalled = false;
+    Math.random = () => {
+      mathRandomCalled = true;
+      throw new Error("Math.random was called!");
+    };
+    try {
+      generateRoomCode(makeRandomBytes([1, 2, 3, 4, 5, 6]));
+      assert.strictEqual(mathRandomCalled, false);
+    } finally {
+      Math.random = origMathRandom;
+    }
+  });
+
+  it("short entropy (too few bytes) throws invalid_entropy", () => {
+    const rb = () => new Uint8Array([1, 2]);
+    assert.throws(() => generateRoomCode(rb), (err) => {
+      assert.strictEqual(err.code, "invalid_entropy");
+      return true;
+    });
+  });
+
+  it("wrong entropy type throws invalid_entropy", () => {
+    const rb = () => new Int8Array(6);
+    assert.throws(() => generateRoomCode(rb), (err) => {
+      assert.strictEqual(err.code, "invalid_entropy");
+      return true;
+    });
+  });
+});
+
+describe("normalizePlayerName", () => {
+  it("returns trimmed string for simple name", () => {
+    assert.strictEqual(normalizePlayerName("Alice"), "Alice");
+  });
+
+  it("strips outer ASCII whitespace (space, tab, CR, LF, FF, VT)", () => {
+    assert.strictEqual(normalizePlayerName("  Alice  "), "Alice");
+    assert.strictEqual(normalizePlayerName("\tAlice\t"), "Alice");
+    assert.strictEqual(normalizePlayerName("\r\nAlice\r\n"), "Alice");
+    assert.strictEqual(normalizePlayerName("\fAlice\f"), "Alice");
+    assert.strictEqual(normalizePlayerName("\vAlice\v"), "Alice");
+  });
+
+  it("collapses internal whitespace runs to single space", () => {
+    assert.strictEqual(normalizePlayerName("Alices  Bob"), "Alices Bob");
+    assert.strictEqual(normalizePlayerName("Alices\t\tBob"), "Alices Bob");
+    assert.strictEqual(normalizePlayerName("Alices\r\nBob"), "Alices Bob");
+    assert.strictEqual(normalizePlayerName("Alices \t \r \n Bob"), "Alices Bob");
+  });
+
+  it("allows only ASCII letters, digits, space, underscore, hyphen", () => {
+    const validPatterns = [
+      "Alice123",
+      "Alice_Bob",
+      "Alice-Bob",
+      "A b",
+      "a",
+      "Z9_-",
+    ];
+    for (const name of validPatterns) {
+      assert.strictEqual(normalizePlayerName(name), name, `expected '${name}' to be valid`);
+    }
+  });
+
+  it("throws Error with code 'invalid_name' for empty string after normalization", () => {
+    assert.throws(() => normalizePlayerName(""), (err) => {
+      assert.strictEqual(err.code, "invalid_name");
+      return true;
+    });
+    assert.throws(() => normalizePlayerName("   "), (err) => {
+      assert.strictEqual(err.code, "invalid_name");
+      return true;
+    });
+  });
+
+  it("throws Error with code 'invalid_name' for name longer than 16 chars", () => {
+    const longName = "A".repeat(17);
+    assert.throws(() => normalizePlayerName(longName), (err) => {
+      assert.strictEqual(err.code, "invalid_name");
+      return true;
+    });
+  });
+
+  it("allows exactly 16 characters", () => {
+    const name = "A".repeat(16);
+    assert.strictEqual(normalizePlayerName(name), name);
+  });
+
+  it("throws Error for invalid characters (e.g. @, #, digits beyond allowed)", () => {
+    const invalidNames = ["Alice@", "Bob#", "Charlie!", "Test%"];
+    for (const name of invalidNames) {
+      assert.throws(() => normalizePlayerName(name), (err) => {
+        assert.strictEqual(err.code, "invalid_name");
+        return true;
+      }, `expected '${name}' to throw`);
+    }
+  });
+
+  it("throws Error for non-string input", () => {
+    const invalidInputs = [123, null, undefined, {}, [], true];
+    for (const input of invalidInputs) {
+      assert.throws(() => normalizePlayerName(input), (err) => {
+        assert.strictEqual(err.code, "invalid_name");
+        return true;
+      }, `expected ${JSON.stringify(input)} to throw`);
+    }
+  });
+
+  it("never substitutes 'Anon'", () => {
+    // Should throw for empty input, never return "Anon"
+    assert.throws(() => normalizePlayerName(""), (err) => {
+      assert.strictEqual(err.code, "invalid_name");
+      return true;
+    });
+  });
+
+  it("proves replacing global Math.random does not affect these functions", () => {
+    const origMathRandom = Math.random;
+    let mathRandomCalled = false;
+    Math.random = () => {
+      mathRandomCalled = true;
+      throw new Error("Math.random was called!");
+    };
+    try {
+      generateRoomCode(() => new Uint8Array([1, 2, 3, 4, 5, 6]));
+      normalizePlayerName("Alice");
+      assert.strictEqual(mathRandomCalled, false);
+    } finally {
+      Math.random = origMathRandom;
+    }
+  });
+});

--- a/tests/room-code.test.mjs
+++ b/tests/room-code.test.mjs
@@ -176,6 +176,16 @@ describe("normalizePlayerName", () => {
     assert.strictEqual(normalizePlayerName(name), name);
   });
 
+  it("rejects non-ASCII names: Ålex, 用户, Player١", () => {
+    const invalidNames = ["Ålex", "用户", "Player١"];
+    for (const name of invalidNames) {
+      assert.throws(() => normalizePlayerName(name), (err) => {
+        assert.strictEqual(err.code, "invalid_name");
+        return true;
+      }, `expected '${name}' to throw`);
+    }
+  });
+
   it("throws Error for invalid characters (e.g. @, #, digits beyond allowed)", () => {
     const invalidNames = ["Alice@", "Bob#", "Charlie!", "Test%"];
     for (const name of invalidNames) {

--- a/tests/room-code.test.mjs
+++ b/tests/room-code.test.mjs
@@ -20,6 +20,14 @@ describe("generateRoomCode", () => {
     return (n) => new Uint8Array(bytes.slice(0, n));
   }
 
+  it("uses default entropy and returns six chars from ROOM_CODE_ALPHABET", () => {
+    const code = generateRoomCode();
+    assert.strictEqual(code.length, 6);
+    for (const ch of code) {
+      assert.ok(ROOM_CODE_ALPHABET.includes(ch), `char '${ch}' not in alphabet`);
+    }
+  });
+
   it("returns exactly 6 characters from the alphabet", () => {
     const rb = makeRandomBytes([1, 2, 3, 4, 5, 6]);
     const code = generateRoomCode(rb);

--- a/tests/room-protocol.test.mjs
+++ b/tests/room-protocol.test.mjs
@@ -123,6 +123,31 @@ describe("room protocol", () => {
     assert.deepEqual(sent.map((entry) => entry.message.code), ["already_in_room", "not_in_room"]);
   });
 
+  it("converts create and join registry failures into typed responses", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    protocol.connect("c2");
+    sent.length = 0;
+
+    assert.doesNotThrow(() => protocol.receive("c1", request("create_room", "r1", { name: "Ålex" })));
+    assert.doesNotThrow(() => protocol.receive("c2", request("join_room", "r2", { code: "ZZZ999", name: "Beta" })));
+    assert.deepEqual(sent.map((entry) => entry.message), [
+      { type: "error", protocolVersion: 1, requestId: "r1", code: "invalid_name" },
+      { type: "error", protocolVersion: 1, requestId: "r2", code: "room_not_found" },
+    ]);
+  });
+
+  it("requires every command to carry a request ID", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    sent.length = 0;
+    protocol.receive("c1", JSON.stringify({ type: "create_room", name: "Alpha" }));
+    assert.deepEqual(sent, [{
+      connectionId: "c1",
+      message: { type: "error", protocolVersion: 1, requestId: null, code: "invalid_request_id" },
+    }]);
+  });
+
   it("fails closed for malformed JSON, message shapes, request IDs, and types", () => {
     const { protocol, sent } = harness();
     protocol.connect("c1");
@@ -156,6 +181,22 @@ describe("room protocol", () => {
     protocol.disconnect("c1");
     assert.equal(registry.getRoom("ABC234").players[0].name, "Alpha");
     assert.doesNotThrow(() => protocol.connect("c1"));
+  });
+
+  it("rejects malformed protocol dependencies at construction", () => {
+    const send = () => {};
+    const completeRegistry = {
+      createRoom() {},
+      joinRoom() {},
+      setPlayerReady() {},
+    };
+    for (const registry of [null, {}, { createRoom() {} }]) {
+      assert.throws(() => createRoomProtocol({ registry, send }), (error) => error?.code === "invalid_configuration");
+    }
+    assert.throws(
+      () => createRoomProtocol({ registry: completeRegistry, send: null }),
+      (error) => error?.code === "invalid_configuration",
+    );
   });
 
   it("rejects malformed or duplicate connection identities", () => {

--- a/tests/room-protocol.test.mjs
+++ b/tests/room-protocol.test.mjs
@@ -1,0 +1,170 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createRoomRegistry } from "../room-registry.js";
+import { createRoomProtocol, ROOM_PROTOCOL_VERSION } from "../room-protocol.js";
+
+function sequence(values) {
+  let index = 0;
+  return () => values[index++];
+}
+
+function harness() {
+  const sent = [];
+  const registry = createRoomRegistry({
+    generateCode: () => "ABC234",
+    createPlayerId: sequence(["p1", "p2"]),
+  });
+  const protocol = createRoomProtocol({
+    registry,
+    send(connectionId, message) {
+      sent.push({ connectionId, message });
+    },
+  });
+  return { protocol, sent, registry };
+}
+
+function request(type, requestId, fields = {}) {
+  return JSON.stringify({ type, requestId, ...fields });
+}
+
+describe("room protocol", () => {
+  it("publishes one frozen protocol version and a connected event", () => {
+    assert.equal(ROOM_PROTOCOL_VERSION, 1);
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    assert.deepEqual(sent, [{
+      connectionId: "c1",
+      message: { type: "connected", protocolVersion: 1 },
+    }]);
+  });
+
+  it("creates a room with connection-bound self identity and invite path", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    sent.length = 0;
+    protocol.receive("c1", request("create_room", "req-1", { name: "Alpha" }));
+    assert.deepEqual(sent, [{
+      connectionId: "c1",
+      message: {
+        type: "room_state",
+        protocolVersion: 1,
+        requestId: "req-1",
+        room: {
+          code: "ABC234",
+          seq: 1,
+          players: [{ id: "p1", name: "Alpha", ready: false }],
+        },
+        self: { playerId: "p1" },
+        invitePath: "/?room=ABC234",
+      },
+    }]);
+  });
+
+  it("joins and broadcasts personalized room state to both connections", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    protocol.connect("c2");
+    protocol.receive("c1", request("create_room", "r1", { name: "Alpha" }));
+    sent.length = 0;
+    protocol.receive("c2", request("join_room", "r2", { code: "abc234", name: "Beta" }));
+
+    assert.equal(sent.length, 2);
+    assert.deepEqual(sent.map((entry) => entry.connectionId), ["c1", "c2"]);
+    assert.equal(sent[0].message.self.playerId, "p1");
+    assert.equal("requestId" in sent[0].message, false);
+    assert.equal(sent[1].message.self.playerId, "p2");
+    assert.equal(sent[1].message.requestId, "r2");
+    assert.equal(sent[0].message.room.seq, 2);
+    assert.deepEqual(sent[0].message.room, sent[1].message.room);
+  });
+
+  it("changes readiness using the connection-bound player and broadcasts", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    protocol.connect("c2");
+    protocol.receive("c1", request("create_room", "r1", { name: "Alpha" }));
+    protocol.receive("c2", request("join_room", "r2", { code: "ABC234", name: "Beta" }));
+    sent.length = 0;
+    protocol.receive("c1", request("set_ready", "r3", { ready: true, expectedSeq: 2 }));
+
+    assert.equal(sent.length, 2);
+    assert.equal(sent[0].message.requestId, "r3");
+    assert.equal("requestId" in sent[1].message, false);
+    assert.equal(sent[0].message.room.seq, 3);
+    assert.equal(sent[0].message.room.players[0].ready, true);
+  });
+
+  it("returns coded registry errors without throwing or mutating session identity", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    protocol.receive("c1", request("create_room", "r1", { name: "Alpha" }));
+    sent.length = 0;
+    protocol.receive("c1", request("set_ready", "r2", { ready: true, expectedSeq: 99 }));
+    assert.deepEqual(sent, [{
+      connectionId: "c1",
+      message: {
+        type: "error",
+        protocolVersion: 1,
+        requestId: "r2",
+        code: "stale_state",
+        currentSeq: 1,
+      },
+    }]);
+  });
+
+  it("rejects commands that conflict with connection session state", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    protocol.connect("c2");
+    protocol.receive("c1", request("create_room", "r1", { name: "Alpha" }));
+    sent.length = 0;
+    protocol.receive("c1", request("create_room", "r2", { name: "Again" }));
+    protocol.receive("c2", request("set_ready", "r3", { ready: true, expectedSeq: 1 }));
+    assert.deepEqual(sent.map((entry) => entry.message.code), ["already_in_room", "not_in_room"]);
+  });
+
+  it("fails closed for malformed JSON, message shapes, request IDs, and types", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    sent.length = 0;
+    protocol.receive("c1", "{");
+    protocol.receive("c1", "null");
+    protocol.receive("c1", JSON.stringify({ type: "create_room", requestId: "bad id", name: "Alpha" }));
+    protocol.receive("c1", request("unknown", "r4"));
+    assert.deepEqual(sent.map((entry) => entry.message), [
+      { type: "error", protocolVersion: 1, requestId: null, code: "invalid_json" },
+      { type: "error", protocolVersion: 1, requestId: null, code: "invalid_message" },
+      { type: "error", protocolVersion: 1, requestId: null, code: "invalid_request_id" },
+      { type: "error", protocolVersion: 1, requestId: "r4", code: "unsupported_message" },
+    ]);
+  });
+
+  it("requires request IDs to be bounded ASCII tokens", () => {
+    const { protocol, sent } = harness();
+    protocol.connect("c1");
+    sent.length = 0;
+    for (const requestId of ["", "x".repeat(65), "snow☃", 7, null]) {
+      protocol.receive("c1", JSON.stringify({ type: "create_room", requestId, name: "Alpha" }));
+    }
+    assert.deepEqual(sent.map((entry) => entry.message.code), Array(5).fill("invalid_request_id"));
+  });
+
+  it("disconnects transport sessions without deleting authoritative rooms", () => {
+    const { protocol, registry } = harness();
+    protocol.connect("c1");
+    protocol.receive("c1", request("create_room", "r1", { name: "Alpha" }));
+    protocol.disconnect("c1");
+    assert.equal(registry.getRoom("ABC234").players[0].name, "Alpha");
+    assert.doesNotThrow(() => protocol.connect("c1"));
+  });
+
+  it("rejects malformed or duplicate connection identities", () => {
+    const { protocol } = harness();
+    for (const id of [null, "", "   ", 7]) {
+      assert.throws(() => protocol.connect(id), (error) => error?.code === "invalid_connection_id");
+    }
+    protocol.connect("c1");
+    assert.throws(() => protocol.connect("c1"), (error) => error?.code === "connection_exists");
+    assert.throws(() => protocol.receive("missing", "{}"), (error) => error?.code === "connection_not_found");
+  });
+});

--- a/tests/room-registry-create.test.mjs
+++ b/tests/room-registry-create.test.mjs
@@ -1,0 +1,114 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createRoomRegistry } from "../room-registry.js";
+
+function sequence(values) {
+  let index = 0;
+  const fn = () => values[index++];
+  fn.calls = () => index;
+  return fn;
+}
+
+function expectCode(expected, action) {
+  assert.throws(action, (error) => {
+    assert.equal(error?.code, expected);
+    return true;
+  });
+}
+
+describe("room registry creation authority", () => {
+  it("creates the exact initial snapshot with normalized name and server identity", () => {
+    const registry = createRoomRegistry({
+      generateCode: () => "ABC234",
+      createPlayerId: () => "player-1",
+    });
+
+    assert.deepEqual(registry.createRoom({ name: "  Alpha\tOne  " }), {
+      playerId: "player-1",
+      room: {
+        code: "ABC234",
+        seq: 1,
+        players: [{ id: "player-1", name: "Alpha One", ready: false }],
+      },
+    });
+  });
+
+  it("accepts only bounded integer maxCodeAttempts", () => {
+    assert.ok(createRoomRegistry({ maxCodeAttempts: 1 }));
+    assert.ok(createRoomRegistry({ maxCodeAttempts: 128 }));
+    for (const value of [0, 129, 1.5, "32", null]) {
+      expectCode("invalid_configuration", () => createRoomRegistry({ maxCodeAttempts: value }));
+    }
+  });
+
+  it("retries collisions and exhausts at the exact configured bound", () => {
+    const codes = sequence(["AAAAAA", "AAAAAA", "BBBBBB", "AAAAAA", "BBBBBB"]);
+    const ids = sequence(["p1", "p2"]);
+    const registry = createRoomRegistry({ generateCode: codes, createPlayerId: ids, maxCodeAttempts: 2 });
+
+    assert.equal(registry.createRoom({ name: "One" }).room.code, "AAAAAA");
+    assert.equal(registry.createRoom({ name: "Two" }).room.code, "BBBBBB");
+    expectCode("room_code_exhausted", () => registry.createRoom({ name: "Three" }));
+    assert.equal(codes.calls(), 5);
+    assert.equal(registry.getRoom("AAAAAA").players.length, 1);
+    assert.equal(registry.getRoom("BBBBBB").players.length, 1);
+  });
+
+  it("rejects malformed generated codes without retaining a room", () => {
+    const codes = sequence(["ABC10O", "CCC333"]);
+    const registry = createRoomRegistry({ generateCode: codes, createPlayerId: () => "p1" });
+
+    expectCode("invalid_room_code", () => registry.createRoom({ name: "Bad" }));
+    assert.equal(registry.getRoom("CCC333"), null);
+    assert.equal(registry.createRoom({ name: "Good" }).room.code, "CCC333");
+  });
+
+  it("rejects invalid player IDs atomically so the same code remains reusable", () => {
+    const ids = sequence(["", "player-ok"]);
+    const registry = createRoomRegistry({ generateCode: () => "DDD444", createPlayerId: ids });
+
+    expectCode("invalid_player_id", () => registry.createRoom({ name: "First" }));
+    assert.equal(registry.getRoom("DDD444"), null);
+    assert.equal(registry.createRoom({ name: "Second" }).room.code, "DDD444");
+  });
+
+  it("rejects non-string player IDs", () => {
+    for (const id of [null, 7, {}, "   "]) {
+      const registry = createRoomRegistry({ generateCode: () => "EEE555", createPlayerId: () => id });
+      expectCode("invalid_player_id", () => registry.createRoom({ name: "Player" }));
+    }
+  });
+
+  it("normalizes lookup codes and returns null for a valid absent room", () => {
+    const registry = createRoomRegistry({ generateCode: () => "FGH678", createPlayerId: () => "p1" });
+    registry.createRoom({ name: "Player" });
+
+    assert.equal(registry.getRoom("  fgh678 ").code, "FGH678");
+    assert.equal(registry.getRoom("ZZZ999"), null);
+  });
+
+  it("rejects invalid lookup codes", () => {
+    const registry = createRoomRegistry();
+    for (const code of [null, "", "ABC12", "ABC10O", "ABC23!"]) {
+      expectCode("invalid_room_code", () => registry.getRoom(code));
+    }
+  });
+
+  it("returns deep detached snapshots from both createRoom and getRoom", () => {
+    const registry = createRoomRegistry({ generateCode: () => "JKL789", createPlayerId: () => "p1" });
+    const created = registry.createRoom({ name: "Player" });
+    created.room.code = "MUTATE";
+    created.room.seq = 999;
+    created.room.players[0].name = "Mutated";
+    created.room.players.push({ id: "x", name: "X", ready: true });
+
+    const first = registry.getRoom("JKL789");
+    assert.deepEqual(first, {
+      code: "JKL789",
+      seq: 1,
+      players: [{ id: "p1", name: "Player", ready: false }],
+    });
+    first.players[0].ready = true;
+    assert.equal(registry.getRoom("JKL789").players[0].ready, false);
+  });
+});

--- a/tests/room-registry-create.test.mjs
+++ b/tests/room-registry-create.test.mjs
@@ -33,6 +33,21 @@ describe("room registry creation authority", () => {
     });
   });
 
+  it("starts every independently created room at sequence one", () => {
+    const codes = sequence(["AAA222", "BBB333"]);
+    const ids = sequence(["p1", "p2"]);
+    const registry = createRoomRegistry({ generateCode: codes, createPlayerId: ids });
+
+    assert.equal(registry.createRoom({ name: "One" }).room.seq, 1);
+    assert.equal(registry.createRoom({ name: "Two" }).room.seq, 1);
+  });
+
+  it("rejects lowercase generated codes instead of silently normalizing them", () => {
+    const registry = createRoomRegistry({ generateCode: () => "abc234", createPlayerId: () => "p1" });
+    expectCode("invalid_room_code", () => registry.createRoom({ name: "Player" }));
+    assert.equal(registry.getRoom("ABC234"), null);
+  });
+
   it("accepts only bounded integer maxCodeAttempts", () => {
     assert.ok(createRoomRegistry({ maxCodeAttempts: 1 }));
     assert.ok(createRoomRegistry({ maxCodeAttempts: 128 }));

--- a/tests/room-registry-join.test.mjs
+++ b/tests/room-registry-join.test.mjs
@@ -1,0 +1,104 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createRoomRegistry } from "../room-registry.js";
+
+function sequence(values) {
+  let index = 0;
+  const fn = () => values[index++];
+  fn.calls = () => index;
+  return fn;
+}
+
+function expectCode(expected, action) {
+  assert.throws(action, (error) => {
+    assert.equal(error?.code, expected);
+    return true;
+  });
+}
+
+function createWaitingRoom({ ids = ["p1", "p2", "p3"] } = {}) {
+  const createPlayerId = sequence(ids);
+  const registry = createRoomRegistry({ generateCode: () => "ABC234", createPlayerId });
+  const created = registry.createRoom({ name: "Alpha One" });
+  return { registry, created, createPlayerId };
+}
+
+describe("room registry join authority", () => {
+  it("joins a normalized code and name as the second unready player", () => {
+    const { registry } = createWaitingRoom();
+    assert.deepEqual(registry.joinRoom({ code: "  abc234 ", name: "  Beta\tTwo " }), {
+      playerId: "p2",
+      room: {
+        code: "ABC234",
+        seq: 2,
+        players: [
+          { id: "p1", name: "Alpha One", ready: false },
+          { id: "p2", name: "Beta Two", ready: false },
+        ],
+      },
+    });
+  });
+
+  it("rejects a valid absent room without changing existing rooms", () => {
+    const { registry } = createWaitingRoom();
+    expectCode("room_not_found", () => registry.joinRoom({ code: "ZZZ999", name: "Beta" }));
+    assert.equal(registry.getRoom("ABC234").seq, 1);
+  });
+
+  it("rejects duplicate normalized names case-insensitively and atomically", () => {
+    const { registry, createPlayerId } = createWaitingRoom();
+    expectCode("name_taken", () => registry.joinRoom({ code: "ABC234", name: " alpha   one " }));
+    assert.deepEqual(registry.getRoom("ABC234"), {
+      code: "ABC234",
+      seq: 1,
+      players: [{ id: "p1", name: "Alpha One", ready: false }],
+    });
+    assert.equal(createPlayerId.calls(), 1);
+  });
+
+  it("rejects a third player with room_full before allocating an identity", () => {
+    const { registry, createPlayerId } = createWaitingRoom();
+    registry.joinRoom({ code: "ABC234", name: "Beta" });
+    expectCode("room_full", () => registry.joinRoom({ code: "ABC234", name: "Gamma" }));
+    assert.equal(createPlayerId.calls(), 2);
+    assert.equal(registry.getRoom("ABC234").seq, 2);
+    assert.equal(registry.getRoom("ABC234").players.length, 2);
+  });
+
+  it("rejects invalid or duplicate player IDs atomically", () => {
+    for (const invalid of ["", "   ", null, 7, {}]) {
+      const { registry } = createWaitingRoom({ ids: ["p1", invalid] });
+      expectCode("invalid_player_id", () => registry.joinRoom({ code: "ABC234", name: "Beta" }));
+      assert.equal(registry.getRoom("ABC234").seq, 1);
+      assert.equal(registry.getRoom("ABC234").players.length, 1);
+    }
+
+    const { registry } = createWaitingRoom({ ids: ["p1", "p1", "p2"] });
+    expectCode("invalid_player_id", () => registry.joinRoom({ code: "ABC234", name: "Beta" }));
+    assert.equal(registry.joinRoom({ code: "ABC234", name: "Beta" }).playerId, "p2");
+  });
+
+  it("rejects invalid room codes through the shared validation boundary", () => {
+    const { registry } = createWaitingRoom();
+    for (const code of [null, "", "ABC12", "ABC10O", "ABC23!"]) {
+      expectCode("invalid_room_code", () => registry.joinRoom({ code, name: "Beta" }));
+    }
+  });
+
+  it("returns detached join snapshots", () => {
+    const { registry } = createWaitingRoom();
+    const joined = registry.joinRoom({ code: "ABC234", name: "Beta" });
+    joined.room.seq = 999;
+    joined.room.players[1].name = "Mutated";
+    joined.room.players.pop();
+
+    assert.deepEqual(registry.getRoom("ABC234"), {
+      code: "ABC234",
+      seq: 2,
+      players: [
+        { id: "p1", name: "Alpha One", ready: false },
+        { id: "p2", name: "Beta", ready: false },
+      ],
+    });
+  });
+});

--- a/tests/room-registry-readiness.test.mjs
+++ b/tests/room-registry-readiness.test.mjs
@@ -1,0 +1,126 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createRoomRegistry } from "../room-registry.js";
+
+function sequence(values) {
+  let index = 0;
+  return () => values[index++];
+}
+
+function expectCode(expected, action, currentSeq) {
+  assert.throws(action, (error) => {
+    assert.equal(error?.code, expected);
+    if (currentSeq !== undefined) assert.equal(error?.currentSeq, currentSeq);
+    return true;
+  });
+}
+
+function createRoom({ joined = false } = {}) {
+  const registry = createRoomRegistry({
+    generateCode: () => "ABC234",
+    createPlayerId: sequence(["p1", "p2"]),
+  });
+  registry.createRoom({ name: "Alpha" });
+  if (joined) registry.joinRoom({ code: "ABC234", name: "Beta" });
+  return registry;
+}
+
+describe("room readiness and state sequence authority", () => {
+  it("changes readiness and increments sequence exactly once", () => {
+    const registry = createRoom();
+    assert.deepEqual(registry.setPlayerReady({
+      code: "abc234",
+      playerId: "p1",
+      ready: true,
+      expectedSeq: 1,
+    }), {
+      code: "ABC234",
+      seq: 2,
+      players: [{ id: "p1", name: "Alpha", ready: true }],
+    });
+  });
+
+  it("sequences readiness changes from both players", () => {
+    const registry = createRoom({ joined: true });
+    assert.equal(registry.setPlayerReady({ code: "ABC234", playerId: "p1", ready: true, expectedSeq: 2 }).seq, 3);
+    const final = registry.setPlayerReady({ code: "ABC234", playerId: "p2", ready: true, expectedSeq: 3 });
+    assert.equal(final.seq, 4);
+    assert.deepEqual(final.players.map((player) => player.ready), [true, true]);
+  });
+
+  it("rejects stale commands and reports the authoritative current sequence", () => {
+    const registry = createRoom({ joined: true });
+    expectCode("stale_state", () => registry.setPlayerReady({
+      code: "ABC234",
+      playerId: "p1",
+      ready: true,
+      expectedSeq: 1,
+    }), 2);
+    assert.equal(registry.getRoom("ABC234").seq, 2);
+    assert.equal(registry.getRoom("ABC234").players[0].ready, false);
+  });
+
+  it("treats an identical readiness command as an idempotent no-op", () => {
+    const registry = createRoom();
+    const unchanged = registry.setPlayerReady({
+      code: "ABC234",
+      playerId: "p1",
+      ready: false,
+      expectedSeq: 1,
+    });
+    assert.equal(unchanged.seq, 1);
+    assert.equal(registry.getRoom("ABC234").seq, 1);
+  });
+
+  it("rejects malformed sequence and readiness values atomically", () => {
+    for (const expectedSeq of [null, 0, -1, 1.5, "1", Number.MAX_SAFE_INTEGER + 1]) {
+      const registry = createRoom();
+      expectCode("invalid_sequence", () => registry.setPlayerReady({
+        code: "ABC234", playerId: "p1", ready: true, expectedSeq,
+      }));
+      assert.equal(registry.getRoom("ABC234").seq, 1);
+    }
+    for (const ready of [null, 0, 1, "true", {}]) {
+      const registry = createRoom();
+      expectCode("invalid_ready", () => registry.setPlayerReady({
+        code: "ABC234", playerId: "p1", ready, expectedSeq: 1,
+      }));
+      assert.equal(registry.getRoom("ABC234").seq, 1);
+    }
+  });
+
+  it("rejects malformed or absent player identities atomically", () => {
+    for (const playerId of [null, "", "   ", 7]) {
+      const registry = createRoom();
+      expectCode("invalid_player_id", () => registry.setPlayerReady({
+        code: "ABC234", playerId, ready: true, expectedSeq: 1,
+      }));
+    }
+    const registry = createRoom();
+    expectCode("player_not_found", () => registry.setPlayerReady({
+      code: "ABC234", playerId: "absent", ready: true, expectedSeq: 1,
+    }));
+    assert.equal(registry.getRoom("ABC234").seq, 1);
+  });
+
+  it("shares room validation and missing-room boundaries", () => {
+    const registry = createRoom();
+    expectCode("invalid_room_code", () => registry.setPlayerReady({
+      code: "bad", playerId: "p1", ready: true, expectedSeq: 1,
+    }));
+    expectCode("room_not_found", () => registry.setPlayerReady({
+      code: "ZZZ999", playerId: "p1", ready: true, expectedSeq: 1,
+    }));
+  });
+
+  it("returns detached readiness snapshots", () => {
+    const registry = createRoom();
+    const snapshot = registry.setPlayerReady({
+      code: "ABC234", playerId: "p1", ready: true, expectedSeq: 1,
+    });
+    snapshot.seq = 999;
+    snapshot.players[0].ready = false;
+    assert.equal(registry.getRoom("ABC234").seq, 2);
+    assert.equal(registry.getRoom("ABC234").players[0].ready, true);
+  });
+});

--- a/tests/room-websocket-server.test.mjs
+++ b/tests/room-websocket-server.test.mjs
@@ -1,0 +1,159 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import WebSocket from "ws";
+import { createRoomRegistry } from "../room-registry.js";
+import { createRoomWebSocketServer } from "../room-websocket-server.js";
+
+const ALLOWED_ORIGIN = "https://stacklogic-dev.game.lan";
+
+function sequence(values) {
+  let index = 0;
+  return () => values[index++];
+}
+
+function nextMessage(socket) {
+  return new Promise((resolve, reject) => {
+    socket.once("message", (data, isBinary) => {
+      try {
+        assert.equal(isBinary, false);
+        resolve(JSON.parse(data.toString("utf8")));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    socket.once("error", reject);
+  });
+}
+
+function nextClose(socket) {
+  return new Promise((resolve) => socket.once("close", (code) => resolve(code)));
+}
+
+async function startHarness({ maxPayloadBytes = 4096 } = {}) {
+  const registry = createRoomRegistry({
+    generateCode: () => "ABC234",
+    createPlayerId: sequence(["p1", "p2"]),
+  });
+  const server = http.createServer((_req, res) => {
+    res.statusCode = 404;
+    res.end("Not found");
+  });
+  const transport = createRoomWebSocketServer({
+    server,
+    registry,
+    allowedOrigin: ALLOWED_ORIGIN,
+    maxPayloadBytes,
+    createConnectionId: sequence(["c1", "c2", "c3"]),
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    url: `ws://127.0.0.1:${port}`,
+    registry,
+    async close(sockets = []) {
+      for (const socket of sockets) socket.terminate();
+      await transport.close();
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  };
+}
+
+function connect(url, { origin = ALLOWED_ORIGIN, path = "/ws" } = {}) {
+  const socket = new WebSocket(`${url}${path}`, { headers: origin === null ? {} : { Origin: origin } });
+  return { socket, connected: nextMessage(socket) };
+}
+
+function rejectedStatus(url, { origin = ALLOWED_ORIGIN, path = "/ws" } = {}) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`${url}${path}`, { headers: origin === null ? {} : { Origin: origin } });
+    socket.once("unexpected-response", (_request, response) => {
+      response.resume();
+      resolve(response.statusCode);
+    });
+    socket.once("error", (error) => {
+      if (error.message.includes("Unexpected server response")) return;
+      reject(error);
+    });
+  });
+}
+
+describe("room WebSocket server", () => {
+  it("carries create and join commands over real WebSocket connections", async () => {
+    const harness = await startHarness();
+    const first = connect(harness.url);
+    const second = connect(harness.url);
+    const sockets = [first.socket, second.socket];
+    try {
+      assert.deepEqual(await first.connected, { type: "connected", protocolVersion: 1 });
+      assert.deepEqual(await second.connected, { type: "connected", protocolVersion: 1 });
+
+      const createdMessage = nextMessage(first.socket);
+      first.socket.send(JSON.stringify({ type: "create_room", requestId: "r1", name: "Alpha" }));
+      const created = await createdMessage;
+      assert.equal(created.type, "room_state");
+      assert.equal(created.room.code, "ABC234");
+      assert.equal(created.self.playerId, "p1");
+
+      const creatorBroadcast = nextMessage(first.socket);
+      const joinerState = nextMessage(second.socket);
+      second.socket.send(JSON.stringify({ type: "join_room", requestId: "r2", code: "abc234", name: "Beta" }));
+      const [toCreator, toJoiner] = await Promise.all([creatorBroadcast, joinerState]);
+      assert.equal(toCreator.room.seq, 2);
+      assert.equal(toCreator.self.playerId, "p1");
+      assert.equal("requestId" in toCreator, false);
+      assert.equal(toJoiner.self.playerId, "p2");
+      assert.equal(toJoiner.requestId, "r2");
+    } finally {
+      await harness.close(sockets);
+    }
+  });
+
+  it("rejects missing, foreign, and prefix-confusable Origins", async () => {
+    const harness = await startHarness();
+    try {
+      assert.equal(await rejectedStatus(harness.url, { origin: null }), 403);
+      assert.equal(await rejectedStatus(harness.url, { origin: "https://evil.example" }), 403);
+      assert.equal(await rejectedStatus(harness.url, { origin: `${ALLOWED_ORIGIN}.evil.example` }), 403);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("rejects upgrades outside the exact /ws path", async () => {
+    const harness = await startHarness();
+    try {
+      assert.equal(await rejectedStatus(harness.url, { path: "/" }), 404);
+      assert.equal(await rejectedStatus(harness.url, { path: "/ws/extra" }), 404);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("closes binary messages with unsupported-data status", async () => {
+    const harness = await startHarness();
+    const client = connect(harness.url);
+    try {
+      await client.connected;
+      const closed = nextClose(client.socket);
+      client.socket.send(Buffer.from([1, 2, 3]), { binary: true });
+      assert.equal(await closed, 1003);
+    } finally {
+      await harness.close([client.socket]);
+    }
+  });
+
+  it("closes oversized text messages with message-too-big status", async () => {
+    const harness = await startHarness({ maxPayloadBytes: 64 });
+    const client = connect(harness.url);
+    try {
+      await client.connected;
+      const closed = nextClose(client.socket);
+      client.socket.send(JSON.stringify({ type: "create_room", requestId: "r1", name: "A".repeat(100) }));
+      assert.equal(await closed, 1009);
+    } finally {
+      await harness.close([client.socket]);
+    }
+  });
+});

--- a/tests/room-websocket-server.test.mjs
+++ b/tests/room-websocket-server.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
+import net from "node:net";
 import WebSocket from "ws";
 import { createRoomRegistry } from "../room-registry.js";
 import { createRoomWebSocketServer } from "../room-websocket-server.js";
@@ -64,6 +65,7 @@ async function startHarness({ maxPayloadBytes = 4096, connectionIds = ["c1", "c2
 
   return {
     url: `ws://127.0.0.1:${port}`,
+    port,
     registry,
     server,
     transport,
@@ -73,6 +75,32 @@ async function startHarness({ maxPayloadBytes = 4096, connectionIds = ["c1", "c2
       await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     },
   };
+}
+
+function rawUpgradeStatus(port, host) {
+  return withinSocketDeadline(new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
+      socket.write([
+        "GET /ws HTTP/1.1",
+        `Host: ${host}`,
+        "Connection: Upgrade",
+        "Upgrade: websocket",
+        "Sec-WebSocket-Version: 13",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        `Origin: ${ALLOWED_ORIGIN}`,
+        "",
+        "",
+      ].join("\r\n"));
+    });
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => { response += chunk; });
+    socket.on("end", () => {
+      const match = /^HTTP\/1\.1 (\d{3})/.exec(response);
+      match ? resolve(Number(match[1])) : reject(new Error("missing_http_status"));
+    });
+    socket.on("error", reject);
+  }), "raw_upgrade_rejection");
 }
 
 function connect(url, { origin = ALLOWED_ORIGIN, path = "/ws" } = {}) {
@@ -128,6 +156,16 @@ describe("room WebSocket server", () => {
       assert.equal(await rejectedStatus(harness.url, { origin: null }), 403);
       assert.equal(await rejectedStatus(harness.url, { origin: "https://evil.example" }), 403);
       assert.equal(await rejectedStatus(harness.url, { origin: `${ALLOWED_ORIGIN}.evil.example` }), 403);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("rejects malformed Host headers without crashing the upgrade listener", async () => {
+    const harness = await startHarness();
+    try {
+      assert.equal(await rawUpgradeStatus(harness.port, "["), 400);
+      assert.equal(await rejectedStatus(harness.url, { path: "/" }), 404);
     } finally {
       await harness.close();
     }

--- a/tests/room-websocket-server.test.mjs
+++ b/tests/room-websocket-server.test.mjs
@@ -43,7 +43,7 @@ function nextClose(socket) {
   );
 }
 
-async function startHarness({ maxPayloadBytes = 4096 } = {}) {
+async function startHarness({ maxPayloadBytes = 4096, connectionIds = ["c1", "c2", "c3"] } = {}) {
   const registry = createRoomRegistry({
     generateCode: () => "ABC234",
     createPlayerId: sequence(["p1", "p2"]),
@@ -57,7 +57,7 @@ async function startHarness({ maxPayloadBytes = 4096 } = {}) {
     registry,
     allowedOrigin: ALLOWED_ORIGIN,
     maxPayloadBytes,
-    createConnectionId: sequence(["c1", "c2", "c3"]),
+    createConnectionId: sequence(connectionIds),
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address();
@@ -65,6 +65,8 @@ async function startHarness({ maxPayloadBytes = 4096 } = {}) {
   return {
     url: `ws://127.0.0.1:${port}`,
     registry,
+    server,
+    transport,
     async close(sockets = []) {
       for (const socket of sockets) socket.terminate();
       await transport.close();
@@ -151,6 +153,39 @@ describe("room WebSocket server", () => {
       assert.equal(await closed, 1003);
     } finally {
       await harness.close([client.socket]);
+    }
+  });
+
+  it("rejects duplicate generated IDs without evicting the original connection", async () => {
+    const harness = await startHarness({ connectionIds: ["same", "same"] });
+    const first = connect(harness.url);
+    const sockets = [first.socket];
+    try {
+      await first.connected;
+
+      const duplicate = new WebSocket(`${harness.url}/ws`, { headers: { Origin: ALLOWED_ORIGIN } });
+      sockets.push(duplicate);
+      assert.equal(await nextClose(duplicate), 1011);
+
+      const state = nextMessage(first.socket);
+      first.socket.send(JSON.stringify({ type: "create_room", requestId: "still-owned", name: "Alpha" }));
+      assert.equal((await state).requestId, "still-owned");
+    } finally {
+      await harness.close(sockets);
+    }
+  });
+
+  it("closes idempotently and removes only its own upgrade listener", async () => {
+    const harness = await startHarness();
+    const unrelatedUpgradeListener = () => {};
+    harness.server.on("upgrade", unrelatedUpgradeListener);
+    try {
+      await harness.transport.close();
+      await harness.transport.close();
+      assert.deepEqual(harness.server.listeners("upgrade"), [unrelatedUpgradeListener]);
+    } finally {
+      harness.server.removeListener("upgrade", unrelatedUpgradeListener);
+      await new Promise((resolve, reject) => harness.server.close((error) => error ? reject(error) : resolve()));
     }
   });
 

--- a/tests/room-websocket-server.test.mjs
+++ b/tests/room-websocket-server.test.mjs
@@ -6,6 +6,16 @@ import { createRoomRegistry } from "../room-registry.js";
 import { createRoomWebSocketServer } from "../room-websocket-server.js";
 
 const ALLOWED_ORIGIN = "https://stacklogic-dev.game.lan";
+const SOCKET_EXPECTATION_TIMEOUT_MS = 1_000;
+
+function withinSocketDeadline(promise, label) {
+  let timer;
+  const deadline = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`socket_timeout:${label}`)), SOCKET_EXPECTATION_TIMEOUT_MS);
+    timer.unref?.();
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
 
 function sequence(values) {
   let index = 0;
@@ -13,7 +23,7 @@ function sequence(values) {
 }
 
 function nextMessage(socket) {
-  return new Promise((resolve, reject) => {
+  return withinSocketDeadline(new Promise((resolve, reject) => {
     socket.once("message", (data, isBinary) => {
       try {
         assert.equal(isBinary, false);
@@ -23,11 +33,14 @@ function nextMessage(socket) {
       }
     });
     socket.once("error", reject);
-  });
+  }), "message");
 }
 
 function nextClose(socket) {
-  return new Promise((resolve) => socket.once("close", (code) => resolve(code)));
+  return withinSocketDeadline(
+    new Promise((resolve) => socket.once("close", (code) => resolve(code))),
+    "close",
+  );
 }
 
 async function startHarness({ maxPayloadBytes = 4096 } = {}) {
@@ -66,17 +79,14 @@ function connect(url, { origin = ALLOWED_ORIGIN, path = "/ws" } = {}) {
 }
 
 function rejectedStatus(url, { origin = ALLOWED_ORIGIN, path = "/ws" } = {}) {
-  return new Promise((resolve, reject) => {
+  return withinSocketDeadline(new Promise((resolve, reject) => {
     const socket = new WebSocket(`${url}${path}`, { headers: origin === null ? {} : { Origin: origin } });
     socket.once("unexpected-response", (_request, response) => {
       response.resume();
       resolve(response.statusCode);
     });
-    socket.once("error", (error) => {
-      if (error.message.includes("Unexpected server response")) return;
-      reject(error);
-    });
-  });
+    socket.once("error", reject);
+  }), "upgrade_rejection");
 }
 
 describe("room WebSocket server", () => {

--- a/tests/server-lifecycle.test.mjs
+++ b/tests/server-lifecycle.test.mjs
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { closeHttpServer, closeServers, settleShutdown } from '../server-lifecycle.js';
+
+describe('server shutdown lifecycle', () => {
+  it('rejects an HTTP close callback error', async () => {
+    const failure = new Error('close_failed');
+    const server = { close(callback) { callback(failure); } };
+    await assert.rejects(closeHttpServer(server), failure);
+  });
+
+  it('force-closes lingering HTTP connections after the shutdown grace period', async () => {
+    let closeCallback;
+    let forceTimer;
+    let forced = false;
+    const server = {
+      close(callback) { closeCallback = callback; },
+      closeIdleConnections() {},
+      closeAllConnections() { forced = true; closeCallback(); },
+    };
+    const closing = closeHttpServer(server, {
+      forceAfterMs: 25,
+      setTimeoutFn(callback) { forceTimer = callback; return 1; },
+      clearTimeoutFn() {},
+    });
+    assert.equal(forced, false);
+    forceTimer();
+    await closing;
+    assert.equal(forced, true);
+  });
+
+  it('attempts HTTP teardown even when WebSocket shutdown throws synchronously', async () => {
+    let httpClosed = false;
+    const failure = new Error('ws_close_failed');
+    await assert.rejects(
+      closeServers({
+        closeWebSocket: () => { throw failure; },
+        closeHttp: async () => { httpClosed = true; },
+      }),
+      failure,
+    );
+    assert.equal(httpClosed, true);
+  });
+
+  it('reports shutdown failure and leaves a controlled nonzero exit code', async () => {
+    const processObject = { exitCode: 0 };
+    const reported = [];
+    await settleShutdown({
+      shutdown: async () => { throw new Error('shutdown_failed'); },
+      processObject,
+      reportError: (...args) => reported.push(args),
+    });
+    assert.equal(processObject.exitCode, 1);
+    assert.equal(reported.length, 1);
+    assert.equal(reported[0][0], 'shutdown_failed');
+  });
+
+  it('sets a zero exit code only after successful shutdown', async () => {
+    const processObject = { exitCode: null };
+    await settleShutdown({ shutdown: async () => {}, processObject, reportError() {} });
+    assert.equal(processObject.exitCode, 0);
+  });
+});

--- a/tests/server-websocket-integration.test.mjs
+++ b/tests/server-websocket-integration.test.mjs
@@ -1,0 +1,105 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import net from "node:net";
+import WebSocket from "ws";
+
+const ORIGIN = "https://stacklogic-dev.game.lan";
+
+async function reservePort() {
+  const probe = net.createServer();
+  await new Promise((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = probe.address();
+  await new Promise((resolve, reject) => probe.close((error) => error ? reject(error) : resolve()));
+  return port;
+}
+
+function waitForMessage(socket, timeoutMs = 1_000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("websocket_message_timeout")), timeoutMs);
+    socket.once("message", (data, isBinary) => {
+      clearTimeout(timer);
+      try {
+        assert.equal(isBinary, false);
+        resolve(JSON.parse(data.toString("utf8")));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+async function waitForHealth(port, child, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`server_exited:${child.exitCode}`);
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (response.ok) return response.json();
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("server_health_timeout");
+}
+
+function waitForExit(child, timeoutMs = 2_000) {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("server_exit_timeout")), timeoutMs);
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+describe("StackLogic server WebSocket integration", () => {
+  it("serves health and room traffic on configured host/port, then shuts down cleanly", async () => {
+    const port = await reservePort();
+    const child = spawn(process.execPath, ["server.js"], {
+      cwd: new URL("..", import.meta.url),
+      env: {
+        ...process.env,
+        HOST: "127.0.0.1",
+        PORT: String(port),
+        STACKLOGIC_ALLOWED_ORIGIN: ORIGIN,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => { output = (output + chunk).slice(-8_192); });
+    child.stderr.on("data", (chunk) => { output = (output + chunk).slice(-8_192); });
+    let socket;
+
+    try {
+      assert.deepEqual(await waitForHealth(port, child), { ok: true });
+
+      socket = new WebSocket(`ws://127.0.0.1:${port}/ws`, { headers: { Origin: ORIGIN } });
+      assert.deepEqual(await waitForMessage(socket), { type: "connected", protocolVersion: 1 });
+
+      const state = waitForMessage(socket);
+      socket.send(JSON.stringify({ type: "create_room", requestId: "integration-1", name: "Alpha" }));
+      const message = await state;
+      assert.equal(message.type, "room_state");
+      assert.equal(message.requestId, "integration-1");
+      assert.match(message.room.code, /^[A-Z2-9]{6}$/);
+      assert.equal(message.self.playerId.length > 0, true);
+
+      child.kill("SIGTERM");
+      assert.equal(await waitForExit(child), 0, output);
+    } finally {
+      socket?.terminate();
+      if (child.exitCode === null) {
+        child.kill("SIGKILL");
+        await waitForExit(child).catch(() => {});
+      }
+    }
+  });
+});

--- a/tests/theme.test.mjs
+++ b/tests/theme.test.mjs
@@ -107,20 +107,18 @@ describe('Theme module', () => {
     }
   });
 
-  it('index.html contains Coming Soon labels for Create Match and Join Match', () => {
-    assert.ok(
-      htmlSrc.includes('Coming Soon'),
-      'index.html must contain Coming Soon labels for multiplayer controls'
+  it('index.html exposes enabled Create Match and Join Match controls', () => {
+    assert.match(
+      htmlSrc,
+      /id="createMatchBtn"[^>]*type="button"/
     );
-    // Verify the multiplayer buttons exist but are disabled/coming soon
-    assert.ok(
-      htmlSrc.includes('createMatchBtn') || htmlSrc.includes('createMatch'),
-      'index.html must contain a Create Match button element'
+    assert.match(
+      htmlSrc,
+      /id="joinMatchBtn"[^>]*type="button"/
     );
-    assert.ok(
-      htmlSrc.includes('joinMatchBtn') || htmlSrc.includes('joinMatch'),
-      'index.html must contain a Join Match button element'
-    );
+    assert.doesNotMatch(htmlSrc, /id="createMatchBtn"[^>]*\bdisabled\b/);
+    assert.doesNotMatch(htmlSrc, /id="joinMatchBtn"[^>]*\bdisabled\b/);
+    assert.doesNotMatch(htmlSrc, /Coming Soon/);
   });
 
   it('index.html Play Solo button is the primary action', () => {


### PR DESCRIPTION
## Outcome
Completes the local-first authoritative multiplayer loop through live opponent state, immutable result resolution, and mutual rematch.

## Safety and authority
- server-authoritative match IDs, seeds, results, and rematch transitions
- room-lifetime match-ID uniqueness and exact client fencing
- strict WebSocket path/origin/Host validation and bounded payloads
- bounded graceful shutdown with forced lingering-connection teardown
- Rematch acceptance is intentionally irrevocable until the fresh authoritative match starts

## Verification
- `npm test`: 245/245 passing across 72 suites
- real two-browser dev acceptance: PASS
- malformed Host raw upgrade: HTTP 400; server remains responsive
- incomplete HTTP-request SIGTERM reproduction: PASS
- independent fail-closed review: PASS, no security concerns or logic errors
- browser evidence SHA-256: `20a8ecaec83593ddd49506bde14a16bc7e6a02c4cd4f0ac31315a33962ba5165`
