### PR TITLE
fix: restore production multiplayer connectivity

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -150,6 +150,6 @@
     <script src="theme.js?v=0.3.0-beta.1"></script>
     <script src="theme-renderer.js?v=0.3.0-beta.1"></script>
     <script type="module" src="game.js?v=0.3.0-beta.1&rev=opponent-state-1"></script>
-    <script type="module" src="room-client.js?v=0.3.0-beta.1&rev=opponent-state-1"></script>
+    <script type="module" src="room-client.js?v=0.3.0-beta.1&rev=public-ws-1"></script>
   </body>
 </html>

--- a/public/room-client.js
+++ b/public/room-client.js
@@ -1,5 +1,8 @@
 const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-const wsUrl = `${wsProtocol}//${window.location.host}/ws`;
+const sameOriginWsUrl = `${wsProtocol}//${window.location.host}/ws`;
+const wsUrl = window.location.hostname === 'vector-sigma-works.github.io'
+  ? 'wss://stacklogic.alexgeslani.com/ws'
+  : sameOriginWsUrl;
 const ws = new WebSocket(wsUrl);
 
 let currentSeq = null;
@@ -44,6 +47,12 @@ async function copyText(text) {
 }
 
 function setStatus(msg) { els.status.textContent = msg; }
+function setLobbyAvailable(available) {
+  els.createBtn.disabled = !available;
+  els.joinBtn.disabled = !available;
+}
+setLobbyAvailable(ws.readyState === WebSocket.OPEN);
+if (ws.readyState !== WebSocket.OPEN) setStatus('Connecting to lobby…');
 function updatePlayerList(room) {
   if (!room || !room.players) { els.players.textContent = ''; return; }
   els.players.textContent = '';
@@ -172,7 +181,7 @@ if (rawPrefill) {
   }
 }
 if (prefilledRoom) els.roomCode.value = prefilledRoom;
-ws.addEventListener('open', () => setStatus('Connected to lobby.'));
+ws.addEventListener('open', () => { setLobbyAvailable(true); setStatus('Connected to lobby.'); });
 ws.addEventListener('message', (e) => {
   let data;
   try { data = JSON.parse(e.data); } catch { return; }
@@ -229,8 +238,8 @@ ws.addEventListener('message', (e) => {
     window.dispatchEvent(new CustomEvent('stacklogic:rematch-status', { detail: { matchId: data.matchId, acceptedPlayerIds: data.acceptedPlayerIds.slice() } }));
   }
 });
-ws.addEventListener('error', () => setStatus('Connection error.'));
-ws.addEventListener('close', () => { invalidateActiveMatch(); setStatus('Disconnected.'); });
+ws.addEventListener('error', () => { setLobbyAvailable(false); setStatus('Connection error.'); });
+ws.addEventListener('close', () => { invalidateActiveMatch(); setLobbyAvailable(false); setStatus('Disconnected.'); });
 els.createBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); if (name) sendMsg('create_room', { name }); });
 els.joinBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); const rawCode = els.roomCode.value.trim(); const code = normalizeRoomCode(rawCode); if (name && code) sendMsg('join_room', { code, name }); });
 els.roomCode.addEventListener('paste', async (e) => {

--- a/room-websocket-server.js
+++ b/room-websocket-server.js
@@ -8,9 +8,11 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
   if (typeof registry !== "object" || registry === null) {
     throw new Error("invalid_configuration");
   }
-  if (typeof allowedOrigin !== "string") {
+  const allowedOrigins = Array.isArray(allowedOrigin) ? allowedOrigin : [allowedOrigin];
+  if (!allowedOrigins.length || allowedOrigins.some((origin) => typeof origin !== "string" || !origin)) {
     throw new Error("invalid_configuration");
   }
+  const originAllowlist = new Set(allowedOrigins);
   if (typeof maxPayloadBytes !== "number" || !Number.isInteger(maxPayloadBytes) || maxPayloadBytes < 1) {
     throw new Error("invalid_configuration");
   }
@@ -57,7 +59,7 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
 
     // Origin validation
     const origin = request.headers.origin;
-    if (origin !== allowedOrigin) {
+    if (!originAllowlist.has(origin)) {
       socket.end(
         "HTTP/1.1 403 Forbidden\r\nContent-Length: 9\r\nConnection: close\r\n\r\nForbidden"
       );

--- a/server.js
+++ b/server.js
@@ -14,9 +14,19 @@ const PORT = PORT_RAW !== undefined ? Number(PORT_RAW) : 3000;
 if (PORT_RAW !== undefined && (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535)) {
   throw new Error('invalid_port');
 }
-const STACKLOGIC_ALLOWED_ORIGIN = process.env.STACKLOGIC_ALLOWED_ORIGIN;
-if (!STACKLOGIC_ALLOWED_ORIGIN || typeof STACKLOGIC_ALLOWED_ORIGIN !== 'string') {
+const STACKLOGIC_ALLOWED_ORIGINS = process.env.STACKLOGIC_ALLOWED_ORIGIN
+  ?.split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+if (!STACKLOGIC_ALLOWED_ORIGINS?.length) {
   throw new Error('missing_allowed_origin');
+}
+for (const origin of STACKLOGIC_ALLOWED_ORIGINS) {
+  let parsed;
+  try { parsed = new URL(origin); } catch { throw new Error('invalid_allowed_origin'); }
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.origin !== origin) {
+    throw new Error('invalid_allowed_origin');
+  }
 }
 
 const app = express();
@@ -102,7 +112,7 @@ const registry = createRoomRegistry();
 const wsServer = createRoomWebSocketServer({
   server,
   registry,
-  allowedOrigin: STACKLOGIC_ALLOWED_ORIGIN,
+  allowedOrigin: STACKLOGIC_ALLOWED_ORIGINS,
   maxPayloadBytes: 4096,
   createConnectionId: randomUUID,
 });

--- a/tests/multiplayer-lobby-ui.test.mjs
+++ b/tests/multiplayer-lobby-ui.test.mjs
@@ -27,7 +27,7 @@ function createElement(id = '') {
   };
 }
 
-function runRoomClient(client, { search = '', modernClipboard = true } = {}) {
+function runRoomClient(client, { search = '', modernClipboard = true, host = 'game.example', socketReadyState = 1 } = {}) {
   const elements = new Map();
   const messages = [];
   const copied = [];
@@ -48,7 +48,7 @@ function runRoomClient(client, { search = '', modernClipboard = true } = {}) {
     constructor(url) {
       this.url = url;
       this.listeners = new Map();
-      this.readyState = FakeWebSocket.OPEN;
+      this.readyState = socketReadyState;
       socket = this;
     }
     addEventListener(type, listener) {
@@ -58,16 +58,21 @@ function runRoomClient(client, { search = '', modernClipboard = true } = {}) {
     }
     send(payload) { messages.push(JSON.parse(payload)); }
     async emit(type, event = {}) {
+      if (type === 'open') this.readyState = FakeWebSocket.OPEN;
+      if (type === 'close') this.readyState = FakeWebSocket.CLOSED;
       for (const listener of this.listeners.get(type) || []) await listener(event);
     }
   }
+  FakeWebSocket.CONNECTING = 0;
   FakeWebSocket.OPEN = 1;
+  FakeWebSocket.CLOSED = 3;
 
   const protocol = modernClipboard ? 'https:' : 'http:';
-  const origin = `${protocol}//game.example`;
+  const origin = `${protocol}//${host}`;
   const location = {
     protocol,
-    host: 'game.example',
+    host,
+    hostname: host,
     origin,
     pathname: '/play',
     href: `${origin}/play${search}`,
@@ -165,7 +170,7 @@ describe('multiplayer lobby UI contract', () => {
     assert.match(html, /id="roomStatus"/);
     assert.match(html, /id="roomPlayers"/);
     assert.match(html, /id="roomReadyBtn"/);
-    assert.match(html, /<script type="module" src="room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1"><\/script>/);
+    assert.match(html, /<script type="module" src="room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1"><\/script>/);
 
     assert.match(client, /new WebSocket\(/);
     assert.match(client, /create_room/);
@@ -180,6 +185,28 @@ describe('multiplayer lobby UI contract', () => {
     assert.match(client, /updateReadyBtn\(\);\s*$/m);
     assert.match(client, /crypto\.randomUUID\(\)/);
     assert.doesNotMatch(client, /Math\.random/);
+  });
+
+  it('uses the public production socket on GitHub Pages and gates lobby controls on connection state', async () => {
+    const client = await read('public/room-client.js');
+    const app = runRoomClient(client, {
+      host: 'vector-sigma-works.github.io',
+      socketReadyState: 0,
+    });
+
+    assert.equal(app.socket.url, 'wss://stacklogic.alexgeslani.com/ws');
+    assert.equal(app.getElement('createMatchBtn').disabled, true);
+    assert.equal(app.getElement('joinMatchBtn').disabled, true);
+    assert.match(app.getElement('roomStatus').textContent, /connect/i);
+
+    await app.socket.emit('open');
+    assert.equal(app.getElement('createMatchBtn').disabled, false);
+    assert.equal(app.getElement('joinMatchBtn').disabled, false);
+
+    await app.socket.emit('close');
+    assert.equal(app.getElement('createMatchBtn').disabled, true);
+    assert.equal(app.getElement('joinMatchBtn').disabled, true);
+    assert.equal(app.getElement('roomStatus').textContent, 'Disconnected.');
   });
 
   it('normalizes join input, pasted invite URLs, and direct room prefills', async () => {

--- a/tests/multiplayer-opponent-state.test.mjs
+++ b/tests/multiplayer-opponent-state.test.mjs
@@ -622,7 +622,7 @@ describe('Pass 03 live opponent state', () => {
     }
     assert.match(indexHtml, /style\.css\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
     assert.match(indexHtml, /game\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
-    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1/);
     assert.match(style, /\.opponent-panel\s*\{/);
     assert.match(style, /grid-template-columns:\s*220px\s+300px\s+160px/);
     assert.match(style, /@media\s*\(max-width:\s*760px\)[\s\S]*\.opponent-panel/);

--- a/tests/pass03d-layout.test.mjs
+++ b/tests/pass03d-layout.test.mjs
@@ -30,7 +30,7 @@ test('ships an accessible responsive opponent panel with exact cache revisions',
 
   assert.match(html, /style\.css\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
   assert.match(html, /game\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
-  assert.match(html, /room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+  assert.match(html, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1/);
 
   assert.match(style, /\.wrap\s*\{[\s\S]*?grid-template-columns:\s*220px\s+300px\s+160px/);
   assert.match(style, /\.opponent-panel\s*\{[\s\S]*?width:\s*160px/);

--- a/tests/release-metadata.test.mjs
+++ b/tests/release-metadata.test.mjs
@@ -31,7 +31,7 @@ describe('release metadata', () => {
       assert.match(indexHtml, new RegExp(`${asset.replace('.', '\\.') }\\?v=${RELEASE.replaceAll('.', '\\.').replace('-', '\\-')}`));
     }
 
-    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
+    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1/);
 
     assert.match(gameJs, /theme-rain-bootstrap\.js\?v=0\.3\.0-beta\.1/);
     assert.match(bootstrapJs, /theme-rain-adapter\.js\?v=0\.3\.0-beta\.1/);

--- a/tests/server-websocket-integration.test.mjs
+++ b/tests/server-websocket-integration.test.mjs
@@ -5,6 +5,7 @@ import net from "node:net";
 import WebSocket from "ws";
 
 const ORIGIN = "https://stacklogic-dev.game.lan";
+const PAGES_ORIGIN = "https://vector-sigma-works.github.io";
 
 async function reservePort() {
   const probe = net.createServer();
@@ -69,7 +70,7 @@ describe("StackLogic server WebSocket integration", () => {
         ...process.env,
         HOST: "127.0.0.1",
         PORT: String(port),
-        STACKLOGIC_ALLOWED_ORIGIN: ORIGIN,
+        STACKLOGIC_ALLOWED_ORIGIN: `${ORIGIN},${PAGES_ORIGIN}`,
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -77,6 +78,7 @@ describe("StackLogic server WebSocket integration", () => {
     child.stdout.on("data", (chunk) => { output = (output + chunk).slice(-8_192); });
     child.stderr.on("data", (chunk) => { output = (output + chunk).slice(-8_192); });
     let socket;
+    let pagesSocket;
 
     try {
       assert.deepEqual(await waitForHealth(port, child), { ok: true });
@@ -92,10 +94,14 @@ describe("StackLogic server WebSocket integration", () => {
       assert.match(message.room.code, /^[A-Z2-9]{6}$/);
       assert.equal(message.self.playerId.length > 0, true);
 
+      pagesSocket = new WebSocket(`ws://127.0.0.1:${port}/ws`, { headers: { Origin: PAGES_ORIGIN } });
+      assert.deepEqual(await waitForMessage(pagesSocket), { type: "connected", protocolVersion: 1 });
+
       child.kill("SIGTERM");
       assert.equal(await waitForExit(child), 0, output);
     } finally {
       socket?.terminate();
+      pagesSocket?.terminate();
       if (child.exitCode === null) {
         child.kill("SIGKILL");
         await waitForExit(child).catch(() => {});


### PR DESCRIPTION
## Incident
GitHub Pages deployed the multiplayer client without a reachable WebSocket backend. The client attempted `wss://vector-sigma-works.github.io/ws`, received 404, and left Create/Join nonfunctional.

## Repair
- route GitHub Pages to the explicit production WebSocket endpoint
- gate Create/Join on real socket readiness
- support an exact, validated origin allowlist for Pages and LAN production
- cache-bust the repaired room client
- add production endpoint and connection-state regressions

## Verification
- `npm test`: 246/246 passed
- Caddy active-version config validation: passed
- production runtime and public two-browser acceptance are required after merge before incident closure