### PR TITLE
fix: bound public multiplayer lifecycle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,7 @@
               <button id="joinMatchBtn" class="btn" type="button">Join Match</button>
               <div id="roomStatus" class="status" aria-live="polite"></div>
               <div id="roomPlayers" class="players-list" aria-live="polite"></div>
-              <button id="roomReadyBtn" class="btn primary" type="button">Ready</button>
+              <button id="roomReadyBtn" class="btn primary" type="button" disabled>Ready</button>
               <button id="copyCodeBtn" class="btn" type="button" disabled>Copy Code</button>
               <button id="copyInviteLinkBtn" class="btn" type="button" disabled>Copy Invite Link</button>
             </div>
@@ -150,6 +150,6 @@
     <script src="theme.js?v=0.3.0-beta.1"></script>
     <script src="theme-renderer.js?v=0.3.0-beta.1"></script>
     <script type="module" src="game.js?v=0.3.0-beta.1&rev=opponent-state-1"></script>
-    <script type="module" src="room-client.js?v=0.3.0-beta.1&rev=public-ws-1"></script>
+    <script type="module" src="room-client.js?v=0.3.0-beta.1&rev=public-ws-2"></script>
   </body>
 </html>

--- a/public/room-client.js
+++ b/public/room-client.js
@@ -52,6 +52,7 @@ function setLobbyAvailable(available) {
   els.joinBtn.disabled = !available;
 }
 setLobbyAvailable(ws.readyState === WebSocket.OPEN);
+updateReadyBtn();
 if (ws.readyState !== WebSocket.OPEN) setStatus('Connecting to lobby…');
 function updatePlayerList(room) {
   if (!room || !room.players) { els.players.textContent = ''; return; }
@@ -168,6 +169,20 @@ function invalidateActiveMatch() {
   opponentUpdateSeq = 0;
 }
 
+function clearRoomState() {
+  currentSeq = null;
+  selfPlayerId = null;
+  roomState = null;
+  finishedMatchId = null;
+  dispatchedMatchIds = new Set();
+  invalidateActiveMatch();
+  els.players.textContent = '';
+  els.readyBtn.disabled = true;
+  els.readyBtn.textContent = 'Ready';
+  els.copyCodeBtn.disabled = true;
+  els.copyInviteLinkBtn.disabled = true;
+}
+
 const params = new URLSearchParams(window.location.search);
 const rawPrefill = params.get('room');
 let prefilledRoom = '';
@@ -193,6 +208,9 @@ ws.addEventListener('message', (e) => {
     els.copyCodeBtn.disabled = false;
     els.copyInviteLinkBtn.disabled = false;
     handleMatchSnapshot(data.room.match, currentSeq);
+  } else if (data.type === 'room_closed') {
+    clearRoomState();
+    setStatus('Room closed because a participant disconnected.');
   } else if (data.type === 'error') setStatus(`Error: ${data.code}`);
   else if (data.type === 'opponent_state') {
     const msgKeys = Object.keys(data);
@@ -239,7 +257,7 @@ ws.addEventListener('message', (e) => {
   }
 });
 ws.addEventListener('error', () => { setLobbyAvailable(false); setStatus('Connection error.'); });
-ws.addEventListener('close', () => { invalidateActiveMatch(); setLobbyAvailable(false); setStatus('Disconnected.'); });
+ws.addEventListener('close', () => { clearRoomState(); setLobbyAvailable(false); setStatus('Disconnected.'); });
 els.createBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); if (name) sendMsg('create_room', { name }); });
 els.joinBtn.addEventListener('click', () => { const name = els.roomName.value.trim(); const rawCode = els.roomCode.value.trim(); const code = normalizeRoomCode(rawCode); if (name && code) sendMsg('join_room', { code, name }); });
 els.roomCode.addEventListener('paste', async (e) => {

--- a/room-protocol.js
+++ b/room-protocol.js
@@ -1,7 +1,7 @@
 const ROOM_PROTOCOL_VERSION = 1;
 
 function createRoomProtocol({ registry, send }) {
-  if (typeof registry !== "object" || registry === null || typeof send !== "function" || typeof registry.createRoom !== "function" || typeof registry.joinRoom !== "function" || typeof registry.setPlayerReady !== "function" || typeof registry.updatePlayerState !== "function" || typeof registry.requestRematch !== "function") {
+  if (typeof registry !== "object" || registry === null || typeof send !== "function" || typeof registry.createRoom !== "function" || typeof registry.deleteRoom !== "function" || typeof registry.joinRoom !== "function" || typeof registry.setPlayerReady !== "function" || typeof registry.updatePlayerState !== "function" || typeof registry.requestRematch !== "function") {
     const err = new Error("invalid_configuration");
     err.code = "invalid_configuration";
     throw err;
@@ -28,7 +28,20 @@ function createRoomProtocol({ registry, send }) {
     if (!sessions.has(connectionId)) {
       return;
     }
+    const session = sessions.get(connectionId);
     sessions.delete(connectionId);
+    if (!session?.room?.code) return;
+
+    registry.deleteRoom({ code: session.room.code });
+    for (const [otherConnectionId, otherSession] of sessions) {
+      if (otherSession?.room?.code !== session.room.code) continue;
+      sessions.set(otherConnectionId, null);
+      send(otherConnectionId, {
+        type: "room_closed",
+        protocolVersion: ROOM_PROTOCOL_VERSION,
+        code: "participant_disconnected",
+      });
+    }
   }
 
   // Validate requestId: if present in message (not undefined), must be a bounded ASCII token

--- a/room-registry.js
+++ b/room-registry.js
@@ -5,6 +5,7 @@ function createRoomRegistry({
   generateCode = generateRoomCode,
   createPlayerId = randomUUID,
   maxCodeAttempts: attemptLimit = 32,
+  maxRooms = 256,
   createMatchId = () => randomUUID(),
   createMatchSeed = () => randomBytes(4).readUInt32BE(0),
 } = {}) {
@@ -14,6 +15,12 @@ function createRoomRegistry({
     attemptLimit < 1 ||
     attemptLimit > 128
   ) {
+    const err = new Error("invalid_configuration");
+    err.code = "invalid_configuration";
+    throw err;
+  }
+
+  if (!Number.isInteger(maxRooms) || maxRooms < 1 || maxRooms > 10_000) {
     const err = new Error("invalid_configuration");
     err.code = "invalid_configuration";
     throw err;
@@ -45,6 +52,11 @@ function createRoomRegistry({
   return {
     createRoom({ name }) {
       const normalizedName = normalizePlayerName(name);
+      if (rooms.size >= maxRooms) {
+        const err = new Error("room_capacity_reached");
+        err.code = "room_capacity_reached";
+        throw err;
+      }
       let lastError = null;
       for (let i = 0; i < attemptLimit; i++) {
         const code = generateCode();
@@ -87,6 +99,19 @@ function createRoomRegistry({
       const err = new Error("room_code_exhausted");
       err.code = "room_code_exhausted";
       throw err;
+    },
+
+    deleteRoom({ code }) {
+      if (typeof code !== "string") {
+        const err = new Error("invalid_room_code");
+        err.code = "invalid_room_code";
+        throw err;
+      }
+      const normalizedCode = code.trim().toUpperCase();
+      validateRoomCode(normalizedCode);
+      const removed = rooms.delete(normalizedCode);
+      issuedMatchIdsByRoom.delete(normalizedCode);
+      return removed;
     },
 
     getRoom(code) {

--- a/room-websocket-server.js
+++ b/room-websocket-server.js
@@ -1,7 +1,7 @@
 import { WebSocketServer } from "ws";
 import { createRoomProtocol } from "./room-protocol.js";
 
-function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayloadBytes = 4096, createConnectionId }) {
+function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayloadBytes = 4096, maxConnections = 200, createConnectionId }) {
   if (typeof server !== "object" || server === null || typeof server.on !== "function") {
     throw new Error("invalid_configuration");
   }
@@ -14,6 +14,9 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
   }
   const originAllowlist = new Set(allowedOrigins);
   if (typeof maxPayloadBytes !== "number" || !Number.isInteger(maxPayloadBytes) || maxPayloadBytes < 1) {
+    throw new Error("invalid_configuration");
+  }
+  if (!Number.isInteger(maxConnections) || maxConnections < 1 || maxConnections > 10_000) {
     throw new Error("invalid_configuration");
   }
   if (typeof createConnectionId !== "function") {
@@ -62,6 +65,13 @@ function createRoomWebSocketServer({ server, registry, allowedOrigin, maxPayload
     if (!originAllowlist.has(origin)) {
       socket.end(
         "HTTP/1.1 403 Forbidden\r\nContent-Length: 9\r\nConnection: close\r\n\r\nForbidden"
+      );
+      return;
+    }
+
+    if (clients.size >= maxConnections) {
+      socket.end(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 19\r\nConnection: close\r\n\r\nService Unavailable"
       );
       return;
     }

--- a/server.js
+++ b/server.js
@@ -29,6 +29,19 @@ for (const origin of STACKLOGIC_ALLOWED_ORIGINS) {
   }
 }
 
+function boundedIntegerEnv(name, fallback, max) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1 || value > max) {
+    throw new Error(`invalid_${name.toLowerCase()}`);
+  }
+  return value;
+}
+
+const STACKLOGIC_MAX_ROOMS = boundedIntegerEnv('STACKLOGIC_MAX_ROOMS', 256, 10_000);
+const STACKLOGIC_MAX_CONNECTIONS = boundedIntegerEnv('STACKLOGIC_MAX_CONNECTIONS', 200, 10_000);
+
 const app = express();
 const DATA_DIR = path.resolve('data');
 const HIGHSCORES_PATH = path.join(DATA_DIR, 'highscores.json');
@@ -108,12 +121,13 @@ app.post('/api/highscores', async (req, res) => {
 });
 
 const server = http.createServer(app);
-const registry = createRoomRegistry();
+const registry = createRoomRegistry({ maxRooms: STACKLOGIC_MAX_ROOMS });
 const wsServer = createRoomWebSocketServer({
   server,
   registry,
   allowedOrigin: STACKLOGIC_ALLOWED_ORIGINS,
   maxPayloadBytes: 4096,
+  maxConnections: STACKLOGIC_MAX_CONNECTIONS,
   createConnectionId: randomUUID,
 });
 

--- a/tests/multiplayer-lobby-ui.test.mjs
+++ b/tests/multiplayer-lobby-ui.test.mjs
@@ -12,7 +12,12 @@ function createElement(id = '') {
   return {
     id,
     value: '',
-    textContent: '',
+    _textContent: '',
+    get textContent() { return this._textContent; },
+    set textContent(value) {
+      this._textContent = value;
+      if (value === '') this.children.length = 0;
+    },
     disabled: id === 'copyCodeBtn' || id === 'copyInviteLinkBtn',
     children: [],
     addEventListener(type, listener) {
@@ -169,8 +174,8 @@ describe('multiplayer lobby UI contract', () => {
     assert.match(html, /id="roomCode"/);
     assert.match(html, /id="roomStatus"/);
     assert.match(html, /id="roomPlayers"/);
-    assert.match(html, /id="roomReadyBtn"/);
-    assert.match(html, /<script type="module" src="room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1"><\/script>/);
+    assert.match(html, /id="roomReadyBtn"[^>]*\bdisabled\b/);
+    assert.match(html, /<script type="module" src="room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-2"><\/script>/);
 
     assert.match(client, /new WebSocket\(/);
     assert.match(client, /create_room/);
@@ -197,15 +202,28 @@ describe('multiplayer lobby UI contract', () => {
     assert.equal(app.socket.url, 'wss://stacklogic.alexgeslani.com/ws');
     assert.equal(app.getElement('createMatchBtn').disabled, true);
     assert.equal(app.getElement('joinMatchBtn').disabled, true);
+    assert.equal(app.getElement('roomReadyBtn').disabled, true);
     assert.match(app.getElement('roomStatus').textContent, /connect/i);
 
     await app.socket.emit('open');
     assert.equal(app.getElement('createMatchBtn').disabled, false);
     assert.equal(app.getElement('joinMatchBtn').disabled, false);
+    assert.equal(app.getElement('roomReadyBtn').disabled, true);
+
+    await app.socket.emit('message', { data: JSON.stringify({
+      type: 'room_state',
+      room: { code: 'ABC234', seq: 1, players: [{ id: 'p1', name: 'Alpha', ready: false }] },
+      self: { playerId: 'p1' },
+    }) });
+    assert.equal(app.getElement('roomReadyBtn').disabled, false);
 
     await app.socket.emit('close');
     assert.equal(app.getElement('createMatchBtn').disabled, true);
     assert.equal(app.getElement('joinMatchBtn').disabled, true);
+    assert.equal(app.getElement('roomReadyBtn').disabled, true);
+    assert.equal(app.getElement('copyCodeBtn').disabled, true);
+    assert.equal(app.getElement('copyInviteLinkBtn').disabled, true);
+    assert.equal(app.getElement('roomPlayers').children.length, 0);
     assert.equal(app.getElement('roomStatus').textContent, 'Disconnected.');
   });
 

--- a/tests/multiplayer-opponent-state.test.mjs
+++ b/tests/multiplayer-opponent-state.test.mjs
@@ -622,7 +622,7 @@ describe('Pass 03 live opponent state', () => {
     }
     assert.match(indexHtml, /style\.css\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
     assert.match(indexHtml, /game\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
-    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1/);
+    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-2/);
     assert.match(style, /\.opponent-panel\s*\{/);
     assert.match(style, /grid-template-columns:\s*220px\s+300px\s+160px/);
     assert.match(style, /@media\s*\(max-width:\s*760px\)[\s\S]*\.opponent-panel/);

--- a/tests/pass03d-layout.test.mjs
+++ b/tests/pass03d-layout.test.mjs
@@ -30,7 +30,7 @@ test('ships an accessible responsive opponent panel with exact cache revisions',
 
   assert.match(html, /style\.css\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
   assert.match(html, /game\.js\?v=0\.3\.0-beta\.1&rev=opponent-state-1/);
-  assert.match(html, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1/);
+  assert.match(html, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-2/);
 
   assert.match(style, /\.wrap\s*\{[\s\S]*?grid-template-columns:\s*220px\s+300px\s+160px/);
   assert.match(style, /\.opponent-panel\s*\{[\s\S]*?width:\s*160px/);

--- a/tests/release-metadata.test.mjs
+++ b/tests/release-metadata.test.mjs
@@ -31,7 +31,7 @@ describe('release metadata', () => {
       assert.match(indexHtml, new RegExp(`${asset.replace('.', '\\.') }\\?v=${RELEASE.replaceAll('.', '\\.').replace('-', '\\-')}`));
     }
 
-    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-1/);
+    assert.match(indexHtml, /room-client\.js\?v=0\.3\.0-beta\.1&rev=public-ws-2/);
 
     assert.match(gameJs, /theme-rain-bootstrap\.js\?v=0\.3\.0-beta\.1/);
     assert.match(bootstrapJs, /theme-rain-adapter\.js\?v=0\.3\.0-beta\.1/);

--- a/tests/room-protocol.test.mjs
+++ b/tests/room-protocol.test.mjs
@@ -174,13 +174,24 @@ describe("room protocol", () => {
     assert.deepEqual(sent.map((entry) => entry.message.code), Array(5).fill("invalid_request_id"));
   });
 
-  it("disconnects transport sessions without deleting authoritative rooms", () => {
-    const { protocol, registry } = harness();
+  it("deletes the authoritative room and resets remaining sessions when a participant disconnects", () => {
+    const { protocol, sent, registry } = harness();
     protocol.connect("c1");
+    protocol.connect("c2");
     protocol.receive("c1", request("create_room", "r1", { name: "Alpha" }));
+    protocol.receive("c2", request("join_room", "r2", { code: "ABC234", name: "Beta" }));
+    sent.length = 0;
+
     protocol.disconnect("c1");
-    assert.equal(registry.getRoom("ABC234").players[0].name, "Alpha");
+
+    assert.equal(registry.getRoom("ABC234"), null);
+    assert.deepEqual(sent, [{
+      connectionId: "c2",
+      message: { type: "room_closed", protocolVersion: 1, code: "participant_disconnected" },
+    }]);
     assert.doesNotThrow(() => protocol.connect("c1"));
+    protocol.receive("c2", request("set_ready", "r3", { ready: true, expectedSeq: 2 }));
+    assert.equal(sent.at(-1).message.code, "not_in_room");
   });
 
   it("rejects malformed protocol dependencies at construction", () => {

--- a/tests/room-registry-create.test.mjs
+++ b/tests/room-registry-create.test.mjs
@@ -42,6 +42,27 @@ describe("room registry creation authority", () => {
     assert.equal(registry.createRoom({ name: "Two" }).room.seq, 1);
   });
 
+  it("bounds room allocation and releases capacity only through explicit deletion", () => {
+    const codes = sequence(["AAA222", "BBB333"]);
+    const ids = sequence(["p1", "p2"]);
+    const registry = createRoomRegistry({ generateCode: codes, createPlayerId: ids, maxRooms: 1 });
+
+    registry.createRoom({ name: "One" });
+    expectCode("room_capacity_reached", () => registry.createRoom({ name: "Two" }));
+    assert.equal(registry.deleteRoom({ code: "AAA222" }), true);
+    assert.equal(registry.getRoom("AAA222"), null);
+    assert.equal(registry.deleteRoom({ code: "AAA222" }), false);
+    assert.equal(registry.createRoom({ name: "Two" }).room.code, "BBB333");
+  });
+
+  it("accepts only bounded integer room capacity", () => {
+    assert.ok(createRoomRegistry({ maxRooms: 1 }));
+    assert.ok(createRoomRegistry({ maxRooms: 10_000 }));
+    for (const value of [0, 10_001, 1.5, "256", null]) {
+      expectCode("invalid_configuration", () => createRoomRegistry({ maxRooms: value }));
+    }
+  });
+
   it("rejects lowercase generated codes instead of silently normalizing them", () => {
     const registry = createRoomRegistry({ generateCode: () => "abc234", createPlayerId: () => "p1" });
     expectCode("invalid_room_code", () => registry.createRoom({ name: "Player" }));

--- a/tests/room-websocket-server.test.mjs
+++ b/tests/room-websocket-server.test.mjs
@@ -44,7 +44,7 @@ function nextClose(socket) {
   );
 }
 
-async function startHarness({ maxPayloadBytes = 4096, connectionIds = ["c1", "c2", "c3"] } = {}) {
+async function startHarness({ maxPayloadBytes = 4096, maxConnections = 200, connectionIds = ["c1", "c2", "c3"] } = {}) {
   const registry = createRoomRegistry({
     generateCode: () => "ABC234",
     createPlayerId: sequence(["p1", "p2"]),
@@ -58,6 +58,7 @@ async function startHarness({ maxPayloadBytes = 4096, connectionIds = ["c1", "c2
     registry,
     allowedOrigin: ALLOWED_ORIGIN,
     maxPayloadBytes,
+    maxConnections,
     createConnectionId: sequence(connectionIds),
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -158,6 +159,17 @@ describe("room WebSocket server", () => {
       assert.equal(await rejectedStatus(harness.url, { origin: `${ALLOWED_ORIGIN}.evil.example` }), 403);
     } finally {
       await harness.close();
+    }
+  });
+
+  it("rejects upgrades beyond the configured concurrent connection bound", async () => {
+    const harness = await startHarness({ maxConnections: 1 });
+    const first = connect(harness.url);
+    try {
+      assert.deepEqual(await first.connected, { type: "connected", protocolVersion: 1 });
+      assert.equal(await rejectedStatus(harness.url), 503);
+    } finally {
+      await harness.close([first.socket]);
     }
   });
 


### PR DESCRIPTION
## Summary
- disable and clear stale lobby controls whenever the socket or room closes
- delete authoritative rooms when a participant disconnects and reset remaining sessions explicitly
- hard-cap rooms and concurrent WebSocket upgrades with fail-closed environment validation
- constrain the production container to 256 MiB and 128 PIDs (host-local Compose config)

## Verification
- `npm test` — 249/249 passing
- `docker compose config -q` — valid
- focused lifecycle/security tests — 43/43 passing

## Review resolution
- resolves the independent Ready-state and unbounded-allocation blockers
- public-host Caddy concern is addressed by the deployed Cloudflare `httpHostHeader: stacklogic.game.lan` ingress and has already passed a real public WSS handshake plus hostile-Origin rejection